### PR TITLE
Correct elemental stoichiometry, equilibrium constants, and CH4 solubility

### DIFF
--- a/src/calliope/chemistry.py
+++ b/src/calliope/chemistry.py
@@ -5,7 +5,8 @@ import logging
 
 from .oxygen_fugacity import OxygenFugacity
 
-log = logging.getLogger("fwl."+__name__)
+log = logging.getLogger('fwl.' + __name__)
+
 
 class ModifiedKeq:
     """Modified equilibrium constant (includes fO2)"""
@@ -17,45 +18,45 @@ class ModifiedKeq:
     def __call__(self, T, fO2_shift):
         fO2 = self.fO2(T, fO2_shift)
         Keq, fO2_stoich = self.callmodel(T)
-        Geq = 10**(Keq-fO2_stoich*fO2)
+        Geq = 10 ** (Keq - fO2_stoich * fO2)
         return Geq
 
     def schaefer_CH4(self, T):
-        '''Schaefer log10Keq for CO2 + 2H2 = CH4 + fO2'''
+        """Schaefer log10Keq for CO2 + 2H2 = CH4 + fO2"""
         # second argument returns stoichiometry of O2
-        return (-16276/T - 5.4738, 1)
+        return (-16276 / T - 5.4738, 1)
 
     def schaefer_C(self, T):
-        '''Schaefer log10Keq for CO2 = CO + 0.5 fO2'''
-        return (-14787/T + 4.5472, 0.5)
+        """Schaefer log10Keq for CO2 = CO + 0.5 fO2"""
+        return (-14787 / T + 4.5472, 0.5)
 
     def schaefer_H(self, T):
-        '''Schaefer log10Keq for H2O = H2 + 0.5 fO2'''
-        return (-12794/T + 2.7768, 0.5)
+        """Schaefer log10Keq for H2O = H2 + 0.5 fO2"""
+        return (-12794 / T + 2.7768, 0.5)
 
     def janaf_CO(self, T):
-        '''JANAF log10Keq, 1500 < K < 3000 for CO2 = CO + 0.5 fO2'''
-        return (-14467.511400133637/T + 4.348135473316284, 0.5)
+        """JANAF log10Keq, 1500 < K < 3000 for CO2 = CO + 0.5 fO2"""
+        return (-14467.511400133637 / T + 4.348135473316284, 0.5)
 
     def janaf_H2(self, T):
-        '''JANAF log10Keq, 1500 < K < 3000 for H2O = H2 + 0.5 fO2'''
-        return (-13152.477779978302/T + 3.038586383273608, 0.5)
+        """JANAF log10Keq, 1500 < K < 3000 for H2O = H2 + 0.5 fO2"""
+        return (-13152.477779978302 / T + 3.038586383273608, 0.5)
 
     def janaf_SO2(self, T):
         # JANAF log10Keq for S2 + 2 O2 = 2 SO2 (doubled form)
         # Coefficients = 2x the formation constant for 0.5 S2 + O2 = SO2
         # fO2_stoich=0: O2 dependence handled by p_O2^2 in the sqrt expression
         # https://doi.org/10.1016/j.gca.2022.08.032
-        return (37774.0/T - 7.6128, 0)
+        return (37774.0 / T - 7.6128, 0)
 
     def janaf_H2S(self, T):
         # JANAF log10Keq for S2 + 2 H2 = 2 H2S (doubled form)
         # Coefficients = 2x the formation constant for 0.5 S2 + H2 = H2S
         # See notebook in `tools/`
-        return (13462.03094/T - 7.24546062, 0)
+        return (13462.03094 / T - 7.24546062, 0)
 
     def janaf_NH3(self, T):
         # JANAF log10Keq for N2 + 3 H2 = 2 NH3 (doubled form)
         # Coefficients = 2x the formation constant
         # See notebook in `tools/`
-        return (5328.031246/T - 11.98476092, 0)
+        return (5328.031246 / T - 11.98476092, 0)

--- a/src/calliope/chemistry.py
+++ b/src/calliope/chemistry.py
@@ -42,16 +42,20 @@ class ModifiedKeq:
         return (-13152.477779978302/T + 3.038586383273608, 0.5)
 
     def janaf_SO2(self, T):
-        # JANAF log10Keq, 900 < K < 2000 for 0.5 S2 + O2 = SO2
+        # JANAF log10Keq for S2 + 2 O2 = 2 SO2 (doubled form)
+        # Coefficients = 2x the formation constant for 0.5 S2 + O2 = SO2
+        # fO2_stoich=0: O2 dependence handled by p_O2^2 in the sqrt expression
         # https://doi.org/10.1016/j.gca.2022.08.032
-        return (18887.0/T - 3.8064, 1)
+        return (37774.0/T - 7.6128, 0)
 
     def janaf_H2S(self, T):
-        # JANAF log10Keq, 200 < K < 4000 for 0.5 S2 + H2 = 0.5 H2S
+        # JANAF log10Keq for S2 + 2 H2 = 2 H2S (doubled form)
+        # Coefficients = 2x the formation constant for 0.5 S2 + H2 = H2S
         # See notebook in `tools/`
-        return (6731.01547/T - 3.62273031, 0)
+        return (13462.03094/T - 7.24546062, 0)
 
     def janaf_NH3(self, T):
-        # JANAF log10Keq, 200 < K < 4000 for N2 + 3 H2 = 2 NH3
+        # JANAF log10Keq for N2 + 3 H2 = 2 NH3 (doubled form)
+        # Coefficients = 2x the formation constant
         # See notebook in `tools/`
-        return ( 2664.015623/T - 5.99238046, 0)
+        return (5328.031246/T - 11.98476092, 0)

--- a/src/calliope/constants.py
+++ b/src/calliope/constants.py
@@ -4,53 +4,53 @@
 from __future__ import annotations
 
 # Earth constants
-M_earth         = 5.972E24              # kg
-R_earth         = 6.335439e6
-R_core_earth    = 3485000.0             # m
-M_core_earth    = 1.94E24               # kg
-ocean_moles     = 7.68894973907177e+22 # moles of H2 (or H2O) in one present-day Earth ocean
+M_earth = 5.972e24  # kg
+R_earth = 6.335439e6
+R_core_earth = 3485000.0  # m
+M_core_earth = 1.94e24  # kg
+ocean_moles = 7.68894973907177e22  # moles of H2 (or H2O) in one present-day Earth ocean
 
 # Physical constants
-const_G = 6.67428e-11        #Gravitational constant (2006 measurements)
-mol             = 6.02214076e+23        # mol definition
-R_gas           = 8.31446261815324      # J K−1 mol−1
+const_G = 6.67428e-11  # Gravitational constant (2006 measurements)
+mol = 6.02214076e23  # mol definition
+R_gas = 8.31446261815324  # J K−1 mol−1
 
 # Molar masses [kg mol-1]
-molar_mass  = {
-            "H"   : 0.001008,
-            "C"   : 0.012011,
-            "O"   : 0.015999,
-            "N"   : 0.014007,
-            "S"   : 0.03206,
-            "He"  : 0.0040026,
-            "H2O" : 0.01801528,
-            "CO2" : 0.04401,
-            "H2"  : 0.00201588,
-            "CH4" : 0.01604,
-            "CO"  : 0.02801,
-            "N2"  : 0.028014,
-            "O2"  : 0.031999,
-            "SO2" : 0.064066,
-            "H2S" : 0.0341,
-            "S2"  : 0.0641,
-            "NH3" : 0.017031,
-        }
+molar_mass = {
+    'H': 0.001008,
+    'C': 0.012011,
+    'O': 0.015999,
+    'N': 0.014007,
+    'S': 0.03206,
+    'He': 0.0040026,
+    'H2O': 0.01801528,
+    'CO2': 0.04401,
+    'H2': 0.00201588,
+    'CH4': 0.01604,
+    'CO': 0.02801,
+    'N2': 0.028014,
+    'O2': 0.031999,
+    'SO2': 0.064066,
+    'H2S': 0.0341,
+    'S2': 0.0641,
+    'NH3': 0.017031,
+}
 
 # Supported volatiles and elements
-volatile_species = [ "H2O", "CO2", "O2", "H2", "CH4", "CO", "N2", "S2", "SO2", "H2S", "NH3"]
-element_list     = [ "H", "O", "C", "N", "S" ]
+volatile_species = ['H2O', 'CO2', 'O2', 'H2', 'CH4', 'CO', 'N2', 'S2', 'SO2', 'H2S', 'NH3']
+element_list = ['H', 'O', 'C', 'N', 'S']
 
 # Plotting colours
-dict_colors  = {
-    "H2O": "#027FB1",
-    "CO2": "#D24901",
-    "O2" : "#00dd00",
-    "H2" : "#008C01",
-    "CH4": "#C720DD",
-    "CO" : "#D1AC02",
-    "N2" : "#870036",
-    "S2" : "#FF8FA1",
-    "SO2": "#00008B",
-    "NH3": "#675200",
-    "H2S": "#aaff22"
+dict_colors = {
+    'H2O': '#027FB1',
+    'CO2': '#D24901',
+    'O2': '#00dd00',
+    'H2': '#008C01',
+    'CH4': '#C720DD',
+    'CO': '#D1AC02',
+    'N2': '#870036',
+    'S2': '#FF8FA1',
+    'SO2': '#00008B',
+    'NH3': '#675200',
+    'H2S': '#aaff22',
 }

--- a/src/calliope/oxygen_fugacity.py
+++ b/src/calliope/oxygen_fugacity.py
@@ -5,7 +5,8 @@ import logging
 
 import numpy as np
 
-log = logging.getLogger("fwl."+__name__)
+log = logging.getLogger('fwl.' + __name__)
+
 
 class OxygenFugacity:
     """log10 oxygen fugacity as a function of temperature"""
@@ -14,13 +15,13 @@ class OxygenFugacity:
         self.callmodel = getattr(self, model)
 
     def __call__(self, T, fO2_shift=0):
-        '''Return log10 fO2'''
+        """Return log10 fO2"""
         return self.callmodel(T) + fO2_shift
 
     def fischer(self, T):
-        '''Fischer et al. (2011) IW'''
-        return 6.94059 -28.1808*1E3/T
+        """Fischer et al. (2011) IW"""
+        return 6.94059 - 28.1808 * 1e3 / T
 
     def oneill(self, T):
-        '''O'Neill and Eggins (2002) IW'''
-        return 2*(-244118+115.559*T-8.474*T*np.log(T))/(np.log(10)*8.31441*T)
+        """O'Neill and Eggins (2002) IW"""
+        return 2 * (-244118 + 115.559 * T - 8.474 * T * np.log(T)) / (np.log(10) * 8.31441 * T)

--- a/src/calliope/solubility.py
+++ b/src/calliope/solubility.py
@@ -136,7 +136,7 @@ class SolubilityCH4(Solubility):
         '''Ardia 2013'''
         p_total *= 1e-4  # Convert to GPa
         p *= 1e-4 # Convert to GPa
-        ppmw = p*np.exp(4.93 - (0.000193 * p_total))
+        ppmw = p*np.exp(4.93 - (1.93 * p_total))
         return ppmw
 
 

--- a/src/calliope/solubility.py
+++ b/src/calliope/solubility.py
@@ -7,7 +7,8 @@ import numpy as np
 
 from .oxygen_fugacity import OxygenFugacity
 
-log = logging.getLogger("fwl."+__name__)
+log = logging.getLogger('fwl.' + __name__)
+
 
 class Solubility:
     """Solubility base class.  All p in bar"""
@@ -16,11 +17,12 @@ class Solubility:
         self.callmodel = getattr(self, composition)
 
     def power_law(self, p, const, exponent):
-        return const*p**exponent
+        return const * p**exponent
 
     def __call__(self, p, *args):
-        '''Dissolved concentration in ppmw in the melt'''
+        """Dissolved concentration in ppmw in the melt"""
         return self.callmodel(p, *args)
+
 
 class SolubilityH2O(Solubility):
     """H2O solubility models"""
@@ -30,23 +32,23 @@ class SolubilityH2O(Solubility):
         super().__init__(composition)
 
     def anorthite_diopside(self, p):
-        '''Newcombe et al. (2017)'''
+        """Newcombe et al. (2017)"""
         return self.power_law(p, 727, 0.5)
 
     def peridotite(self, p):
-        '''Sossi et al. (2022)'''
+        """Sossi et al. (2022)"""
         return self.power_law(p, 524, 0.5)
 
     def basalt_dixon(self, p):
-        '''Dixon et al. (1995) refit by Paolo Sossi'''
+        """Dixon et al. (1995) refit by Paolo Sossi"""
         return self.power_law(p, 965, 0.5)
 
     def basalt_wilson(self, p):
-        '''Hamilton (1964) and Wilson and Head (1981)'''
+        """Hamilton (1964) and Wilson and Head (1981)"""
         return self.power_law(p, 215, 0.7)
 
     def lunar_glass(self, p):
-        '''Newcombe et al. (2017)'''
+        """Newcombe et al. (2017)"""
         return self.power_law(p, 683, 0.5)
 
 
@@ -67,16 +69,16 @@ class SolubilityS2(Solubility):
             return 0.0
 
         # melt composition [wt%]
-        x_FeO  = 10.0
+        x_FeO = 10.0
 
         # calculate fO2 [bar]
-        fO2 = 10**self.fO2_model(temp, fO2_shift)
+        fO2 = 10 ** self.fO2_model(temp, fO2_shift)
 
         # calculate log(Ss)
-        out = 13.8426 - 26.476e3/temp + 0.124*x_FeO + 0.5*np.log(p/fO2)
+        out = 13.8426 - 26.476e3 / temp + 0.124 * x_FeO + 0.5 * np.log(p / fO2)
 
         # convert to concentration ppmw
-        out = np.exp(out) #* 10000.0
+        out = np.exp(out)  # * 10000.0
 
         return out
 
@@ -88,9 +90,9 @@ class SolubilityCO2(Solubility):
         super().__init__(composition)
 
     def basalt_dixon(self, p, temp):
-        '''Dixon et al. (1995)'''
-        ppmw = (3.8E-7)*p*np.exp(-23*(p-1)/(83.15*temp))
-        ppmw = 1.0E4*(4400*ppmw) / (36.6-44*ppmw)
+        """Dixon et al. (1995)"""
+        ppmw = (3.8e-7) * p * np.exp(-23 * (p - 1) / (83.15 * temp))
+        ppmw = 1.0e4 * (4400 * ppmw) / (36.6 - 44 * ppmw)
         return ppmw
 
 
@@ -101,30 +103,31 @@ class SolubilityN2(Solubility):
         super().__init__(composition)
 
         # melt composition
-        x_SiO2  = 0.56
+        x_SiO2 = 0.56
         x_Al2O3 = 0.11
-        x_TiO2  = 0.01
-        self.dasfac_2 = np.exp(4.67 + 7.11*x_SiO2 - 13.06*x_Al2O3 - 120.67*x_TiO2)
+        x_TiO2 = 0.01
+        self.dasfac_2 = np.exp(4.67 + 7.11 * x_SiO2 - 13.06 * x_Al2O3 - 120.67 * x_TiO2)
 
     def libourel(self, p):
-        '''Libourel et al. (2003)'''
+        """Libourel et al. (2003)"""
         ppmw = self.power_law(p, 0.0611, 1.0)
         return ppmw
 
     def dasgupta(self, p, ptot, temp, fO2_shift):
-        '''Dasgupta et al. (2022)'''
+        """Dasgupta et al. (2022)"""
 
         # convert bar to GPa
-        pb_N2  = p * 1.0e-4
+        pb_N2 = p * 1.0e-4
         pb_tot = ptot * 1.0e-4
 
         pb_tot = max(pb_tot, 1e-15)
 
         # calculate N2 concentration in melt
-        ppmw  = pb_N2**0.5 * np.exp(5908.0 * pb_tot**0.5/temp - 1.6*fO2_shift)
+        ppmw = pb_N2**0.5 * np.exp(5908.0 * pb_tot**0.5 / temp - 1.6 * fO2_shift)
         ppmw += pb_N2 * self.dasfac_2
 
         return ppmw
+
 
 class SolubilityCH4(Solubility):
     """CH4 solubility models"""
@@ -133,10 +136,10 @@ class SolubilityCH4(Solubility):
         super().__init__(composition)
 
     def basalt_ardia(self, p, p_total):
-        '''Ardia 2013'''
+        """Ardia 2013"""
         p_total *= 1e-4  # Convert to GPa
-        p *= 1e-4 # Convert to GPa
-        ppmw = p*np.exp(4.93 - (1.93 * p_total))
+        p *= 1e-4  # Convert to GPa
+        ppmw = p * np.exp(4.93 - (1.93 * p_total))
         return ppmw
 
 
@@ -147,6 +150,6 @@ class SolubilityCO(Solubility):
         super().__init__(composition)
 
     def mafic_armstrong(self, p, p_total):
-        '''Armstrong 2015'''
+        """Armstrong 2015"""
         ppmw = 10 ** (-0.738 + 0.876 * np.log10(p) - 5.44e-5 * p_total)
         return ppmw

--- a/src/calliope/solve.py
+++ b/src/calliope/solve.py
@@ -23,7 +23,7 @@ from .solubility import (
     SolubilityS2,
 )
 
-log = logging.getLogger("fwl."+__name__)
+log = logging.getLogger('fwl.' + __name__)
 
 # Solve partial pressures functions
 # Originally formulated by Dan Bower
@@ -37,8 +37,10 @@ log = logging.getLogger("fwl."+__name__)
 
 TRUNC_MASS = 1e1
 
+
 def is_included(gas, ddict):
-    return bool(ddict[gas+"_included"]>0)
+    return bool(ddict[gas + '_included'] > 0)
+
 
 def get_partial_pressures(pin, ddict):
     """Partial pressure of all considered species from oxidised species"""
@@ -46,7 +48,7 @@ def get_partial_pressures(pin, ddict):
     # we only need to know pH2O, pCO2, and pN2, since reduced species
     # can be directly determined from equilibrium chemistry
 
-    fO2_shift = ddict["fO2_shift_IW"]
+    fO2_shift = ddict['fO2_shift_IW']
 
     # return results in dict, to be explicit about which pressure
     # corresponds to which volatile
@@ -60,53 +62,53 @@ def get_partial_pressures(pin, ddict):
     p_d['H2O'] = pin['H2O']
 
     # H2
-    if is_included("H2", ddict):
+    if is_included('H2', ddict):
         gamma = ModifiedKeq('janaf_H2')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['H2'] = gamma*pin["H2O"]
+        p_d['H2'] = gamma * pin['H2O']
 
     # CO2
     p_d['CO2'] = pin['CO2']
 
     # CO
-    if is_included("CO", ddict):
+    if is_included('CO', ddict):
         gamma = ModifiedKeq('janaf_CO')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['CO'] = gamma*pin["CO2"]
+        p_d['CO'] = gamma * pin['CO2']
 
     # CH4
-    if is_included("H2",ddict) and is_included("CH4",ddict):
+    if is_included('H2', ddict) and is_included('CH4', ddict):
         gamma = ModifiedKeq('schaefer_CH4')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['CH4'] = gamma*pin["CO2"]*p_d['H2']**2.0
+        p_d['CH4'] = gamma * pin['CO2'] * p_d['H2'] ** 2.0
 
     # N2
-    p_d['N2']  = pin['N2']
+    p_d['N2'] = pin['N2']
 
     # NH3
-    if is_included("NH3", ddict):
+    if is_included('NH3', ddict):
         gamma = ModifiedKeq('janaf_NH3')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['NH3']  = (gamma*pin['N2']*p_d['H2']**3)**0.5
+        p_d['NH3'] = (gamma * pin['N2'] * p_d['H2'] ** 3) ** 0.5
 
     # O2
     fO2_model = OxygenFugacity()
-    p_d['O2'] = 10.0**fO2_model(ddict['T_magma'], fO2_shift)
+    p_d['O2'] = 10.0 ** fO2_model(ddict['T_magma'], fO2_shift)
 
     # S2
     p_d['S2'] = pin['S2']
 
     # SO2
-    if is_included("SO2", ddict):
+    if is_included('SO2', ddict):
         gamma = ModifiedKeq('janaf_SO2')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['SO2']  = (gamma*pin['S2']*p_d['O2']**2)**0.5
+        p_d['SO2'] = (gamma * pin['S2'] * p_d['O2'] ** 2) ** 0.5
 
     # H2S
-    if is_included("H2S", ddict) and is_included("H2", ddict):
+    if is_included('H2S', ddict) and is_included('H2', ddict):
         gamma = ModifiedKeq('janaf_H2S')
         gamma = gamma(ddict['T_magma'], fO2_shift)
-        p_d['H2S']  = (gamma*pin['S2']*p_d['H2']**2)**0.5
+        p_d['H2S'] = (gamma * pin['S2'] * p_d['H2'] ** 2) ** 0.5
 
     # Ensure positive
     for k in p_d.keys():
@@ -115,10 +117,10 @@ def get_partial_pressures(pin, ddict):
     return p_d
 
 
-
 def get_total_pressure(p_d):
     """Sum partial pressures to get total pressure"""
     return sum(p_d.values())
+
 
 def atmosphere_mean_molar_mass(p_d):
     """Mean molar mass of the atmosphere"""
@@ -127,11 +129,10 @@ def atmosphere_mean_molar_mass(p_d):
 
     mu_atm = 0
     for key, value in p_d.items():
-        mu_atm += molar_mass[key]*value
+        mu_atm += molar_mass[key] * value
     mu_atm /= ptot
 
     return mu_atm
-
 
 
 def atmosphere_mass(pin, ddict):
@@ -143,55 +144,57 @@ def atmosphere_mass(pin, ddict):
     mass_atm_d = {}
     for key, value in p_d.items():
         # 1.0E5 because pressures are in bar
-        mass_atm_d[key] = value*1.0E5/ddict['gravity']
-        mass_atm_d[key] *= 4.0*np.pi*ddict['radius']**2.0
-        mass_atm_d[key] *= molar_mass[key]/mu_atm
+        mass_atm_d[key] = value * 1.0e5 / ddict['gravity']
+        mass_atm_d[key] *= 4.0 * np.pi * ddict['radius'] ** 2.0
+        mass_atm_d[key] *= molar_mass[key] / mu_atm
 
     # total mass of H
-    mass_atm_d['H'] = 2*mass_atm_d['H2O'] / molar_mass['H2O']
+    mass_atm_d['H'] = 2 * mass_atm_d['H2O'] / molar_mass['H2O']
     if is_included('H2', ddict):
-        mass_atm_d['H'] += 2*mass_atm_d['H2'] / molar_mass['H2']
+        mass_atm_d['H'] += 2 * mass_atm_d['H2'] / molar_mass['H2']
     if is_included('CH4', ddict):
-        mass_atm_d['H'] += 4*mass_atm_d['CH4'] / molar_mass['CH4']    # note factor 4 to account for stoichiometry
-    if is_included("H2S", ddict):
-        mass_atm_d['H'] += 2*mass_atm_d['H2S'] / molar_mass['H2S']
-    if is_included("NH3", ddict):
-        mass_atm_d['H'] += 3*mass_atm_d['NH3'] / molar_mass['NH3']
+        mass_atm_d['H'] += (
+            4 * mass_atm_d['CH4'] / molar_mass['CH4']
+        )  # note factor 4 to account for stoichiometry
+    if is_included('H2S', ddict):
+        mass_atm_d['H'] += 2 * mass_atm_d['H2S'] / molar_mass['H2S']
+    if is_included('NH3', ddict):
+        mass_atm_d['H'] += 3 * mass_atm_d['NH3'] / molar_mass['NH3']
     # below converts moles of H2 to mass of H
     mass_atm_d['H'] *= molar_mass['H']
 
     # total mass of C
     mass_atm_d['C'] = mass_atm_d['CO2'] / molar_mass['CO2']
-    if is_included("CO", ddict):
+    if is_included('CO', ddict):
         mass_atm_d['C'] += mass_atm_d['CO'] / molar_mass['CO']
-    if is_included("CH4", ddict):
+    if is_included('CH4', ddict):
         mass_atm_d['C'] += mass_atm_d['CH4'] / molar_mass['CH4']
     # below converts moles of C to mass of C
     mass_atm_d['C'] *= molar_mass['C']
 
     # total mass of N
-    mass_atm_d['N'] = 2*mass_atm_d['N2']/molar_mass['N2']
-    if is_included("NH3", ddict):
+    mass_atm_d['N'] = 2 * mass_atm_d['N2'] / molar_mass['N2']
+    if is_included('NH3', ddict):
         mass_atm_d['N'] += mass_atm_d['NH3'] / molar_mass['NH3']
     mass_atm_d['N'] *= molar_mass['N']
 
     # total mass of O
     mass_atm_d['O'] = mass_atm_d['H2O'] / molar_mass['H2O']
-    mass_atm_d['O'] += 2*mass_atm_d['O2'] / molar_mass['O2']
-    if is_included("CO", ddict):
+    mass_atm_d['O'] += 2 * mass_atm_d['O2'] / molar_mass['O2']
+    if is_included('CO', ddict):
         mass_atm_d['O'] += mass_atm_d['CO'] / molar_mass['CO']
-    if is_included("CO2", ddict):
+    if is_included('CO2', ddict):
         mass_atm_d['O'] += mass_atm_d['CO2'] / molar_mass['CO2'] * 2.0
-    if is_included("SO2", ddict):
+    if is_included('SO2', ddict):
         mass_atm_d['O'] += mass_atm_d['SO2'] / molar_mass['SO2'] * 2.0
     # below converts moles of O to mass of O
     mass_atm_d['O'] *= molar_mass['O']
 
     # total mass of S
-    mass_atm_d['S'] = 2*mass_atm_d['S2'] / molar_mass['S2']
-    if is_included("SO2", ddict):
+    mass_atm_d['S'] = 2 * mass_atm_d['S2'] / molar_mass['S2']
+    if is_included('SO2', ddict):
         mass_atm_d['S'] += mass_atm_d['SO2'] / molar_mass['SO2']
-    if is_included("H2S", ddict):
+    if is_included('H2S', ddict):
         mass_atm_d['S'] += mass_atm_d['H2S'] / molar_mass['H2S']
     mass_atm_d['S'] *= molar_mass['S']
 
@@ -199,7 +202,6 @@ def atmosphere_mass(pin, ddict):
         mass_atm_d[e] = max(0.0, mass_atm_d[e])
 
     return mass_atm_d
-
 
 
 def dissolved_mass(pin, ddict):
@@ -210,62 +212,62 @@ def dissolved_mass(pin, ddict):
     p_d = get_partial_pressures(pin, ddict)
     ptot = get_total_pressure(p_d)
 
-    prefactor = 1E-6*ddict['M_mantle']*ddict['Phi_global']
+    prefactor = 1e-6 * ddict['M_mantle'] * ddict['Phi_global']
 
     # H2O
-    sol_H2O = SolubilityH2O() # gets the default solubility model
+    sol_H2O = SolubilityH2O()  # gets the default solubility model
     ppmw_H2O = sol_H2O(p_d['H2O'])
-    mass_int_d['H2O'] = prefactor*ppmw_H2O
+    mass_int_d['H2O'] = prefactor * ppmw_H2O
 
     # CO2
-    sol_CO2 = SolubilityCO2() # gets the default solubility model
+    sol_CO2 = SolubilityCO2()  # gets the default solubility model
     ppmw_CO2 = sol_CO2(p_d['CO2'], ddict['T_magma'])
-    mass_int_d['CO2'] = prefactor*ppmw_CO2
+    mass_int_d['CO2'] = prefactor * ppmw_CO2
 
     # CO
-    if is_included("CO", ddict):
-        sol_CO = SolubilityCO() # gets the default solubility model
-        ppmw_CO = sol_CO(p_d["CO"], ptot)
-        mass_int_d['CO'] = prefactor*ppmw_CO
+    if is_included('CO', ddict):
+        sol_CO = SolubilityCO()  # gets the default solubility model
+        ppmw_CO = sol_CO(p_d['CO'], ptot)
+        mass_int_d['CO'] = prefactor * ppmw_CO
     else:
         mass_int_d['CO'] = 0.0
 
     # CH4
-    if is_included("CH4", ddict):
-        sol_CH4 = SolubilityCH4() # gets the default solubility model
-        ppmw_CH4 = sol_CH4(p_d["CH4"], ptot)
-        mass_int_d['CH4'] = prefactor*ppmw_CH4
+    if is_included('CH4', ddict):
+        sol_CH4 = SolubilityCH4()  # gets the default solubility model
+        ppmw_CH4 = sol_CH4(p_d['CH4'], ptot)
+        mass_int_d['CH4'] = prefactor * ppmw_CH4
     else:
         mass_int_d['CH4'] = 0.0
 
     # N2
-    sol_N2 = SolubilityN2("dasgupta") # calculate fO2-dependent solubility
-    ppmw_N2 = sol_N2(p_d['N2'], ptot,  ddict['T_magma'],  ddict['fO2_shift_IW'])
-    mass_int_d['N2'] = prefactor*ppmw_N2
+    sol_N2 = SolubilityN2('dasgupta')  # calculate fO2-dependent solubility
+    ppmw_N2 = sol_N2(p_d['N2'], ptot, ddict['T_magma'], ddict['fO2_shift_IW'])
+    mass_int_d['N2'] = prefactor * ppmw_N2
 
     # S2
     sol_S2 = SolubilityS2()
-    ppmw_S2 = sol_S2(p_d["S2"], ddict["T_magma"], ddict['fO2_shift_IW'])
-    mass_int_d['S2'] = prefactor*ppmw_S2
+    ppmw_S2 = sol_S2(p_d['S2'], ddict['T_magma'], ddict['fO2_shift_IW'])
+    mass_int_d['S2'] = prefactor * ppmw_S2
 
     # now get totals of H, C, N, O, S
-    mass_int_d['H'] = mass_int_d['H2O']*2/molar_mass['H2O']
-    if is_included("CH4", ddict):
-        mass_int_d['H'] += mass_int_d['CH4']*4/molar_mass["CH4"]
+    mass_int_d['H'] = mass_int_d['H2O'] * 2 / molar_mass['H2O']
+    if is_included('CH4', ddict):
+        mass_int_d['H'] += mass_int_d['CH4'] * 4 / molar_mass['CH4']
     mass_int_d['H'] *= molar_mass['H']
 
-    mass_int_d['C'] = mass_int_d['CO2']/molar_mass['CO2']
-    if is_included("CO", ddict):
-        mass_int_d['C'] += mass_int_d['CO']/molar_mass['CO']
-    if is_included("CH4", ddict):
-        mass_int_d['C'] += mass_int_d['CH4']/molar_mass['CH4']
+    mass_int_d['C'] = mass_int_d['CO2'] / molar_mass['CO2']
+    if is_included('CO', ddict):
+        mass_int_d['C'] += mass_int_d['CO'] / molar_mass['CO']
+    if is_included('CH4', ddict):
+        mass_int_d['C'] += mass_int_d['CH4'] / molar_mass['CH4']
     mass_int_d['C'] *= molar_mass['C']
 
     mass_int_d['N'] = mass_int_d['N2']
 
     mass_int_d['O'] = mass_int_d['H2O'] / molar_mass['H2O']
     mass_int_d['O'] += mass_int_d['CO2'] / molar_mass['CO2'] * 2.0
-    if is_included("CO", ddict):
+    if is_included('CO', ddict):
         mass_int_d['O'] += mass_int_d['CO'] / molar_mass['CO']
     mass_int_d['O'] *= molar_mass['O']
 
@@ -276,15 +278,11 @@ def dissolved_mass(pin, ddict):
 
     return mass_int_d
 
+
 def func(pin_arr, ddict, mass_target_d):
     """Function to compute the residual of the mass balance given the partial pressures [bar]"""
 
-    pin_dict = {
-        "H2O" : pin_arr[0],
-        "CO2" : pin_arr[1],
-        "N2"  : pin_arr[2],
-        "S2" :  pin_arr[3]
-    }
+    pin_dict = {'H2O': pin_arr[0], 'CO2': pin_arr[1], 'N2': pin_arr[2], 'S2': pin_arr[3]}
 
     # get atmospheric masses
     mass_atm_d = atmosphere_mass(pin_dict, ddict)
@@ -293,27 +291,28 @@ def func(pin_arr, ddict, mass_target_d):
     mass_int_d = dissolved_mass(pin_dict, ddict)
 
     # compute residuals
-    res_l = [0.0]*4
-    for i,vol in enumerate(['H','C','N','S']):
+    res_l = [0.0] * 4
+    for i, vol in enumerate(['H', 'C', 'N', 'S']):
         res_l[i] = mass_atm_d[vol] + mass_int_d[vol] - mass_target_d[vol]
 
     return res_l
+
 
 def obj(pin_arr, ddict, mass_target_d):
     """Function to compute the residual of the mass balance given the partial pressures [bar]"""
 
     res_l = func(pin_arr, ddict, mass_target_d)
-    return np.dot(res_l, res_l)**0.5
+    return np.dot(res_l, res_l) ** 0.5
 
 
 def get_initial_pressures(target_d):
     """Get initial guesses of partial pressures"""
 
     # all in log-bar
-    pH2O = 10**np.random.uniform(low=-12, high=5)
-    pCO2 = 10**np.random.uniform(low=-12, high=5)
-    pN2  = 10**np.random.uniform(low=-12, high=5)
-    pS2  = 10**np.random.uniform(low=-12, high=5)
+    pH2O = 10 ** np.random.uniform(low=-12, high=5)
+    pCO2 = 10 ** np.random.uniform(low=-12, high=5)
+    pN2 = 10 ** np.random.uniform(low=-12, high=5)
+    pS2 = 10 ** np.random.uniform(low=-12, high=5)
 
     return pH2O, pCO2, pN2, pS2
 
@@ -321,16 +320,17 @@ def get_initial_pressures(target_d):
 def get_target_from_params(ddict):
 
     N_ocean_moles = ddict['hydrogen_earth_oceans']
-    CH_ratio =      ddict['CH_ratio']
-    Nitrogen =      ddict['nitrogen_ppmw']
-    Sulfur =        ddict['sulfur_ppmw']
+    CH_ratio = ddict['CH_ratio']
+    Nitrogen = ddict['nitrogen_ppmw']
+    Sulfur = ddict['sulfur_ppmw']
 
     H_kg = N_ocean_moles * ocean_moles * molar_mass['H2']
     C_kg = CH_ratio * H_kg
-    N_kg = Nitrogen * 1.0E-6 * ddict["M_mantle"]
-    S_kg = Sulfur * 1.0E-6 * ddict["M_mantle"]
+    N_kg = Nitrogen * 1.0e-6 * ddict['M_mantle']
+    S_kg = Sulfur * 1.0e-6 * ddict['M_mantle']
     target_d = {'H': H_kg, 'C': C_kg, 'N': N_kg, 'S': S_kg}
     return target_d
+
 
 def get_target_from_pressures(ddict):
 
@@ -340,32 +340,32 @@ def get_target_from_pressures(ddict):
     pin_dict = {}
     for vol in volatile_species:
         if is_included(vol, ddict):
-            pin_dict[vol] = ddict[vol+"_initial_bar"]
+            pin_dict[vol] = ddict[vol + '_initial_bar']
 
     p_tot = np.sum(list(pin_dict.values()))
     if p_tot < 1.0e-3:
-        raise Exception("Initial surface pressure too low! (%.2e bar)"%p_tot)
+        raise Exception('Initial surface pressure too low! (%.2e bar)' % p_tot)
 
     # Check if no sulfur is present
-    ptot_S = pin_dict["S2"]
-    if is_included("SO2", ddict):
-        ptot_S += pin_dict["SO2"]
-    if is_included("H2S", ddict):
-        ptot_S += pin_dict["H2S"]
+    ptot_S = pin_dict['S2']
+    if is_included('SO2', ddict):
+        ptot_S += pin_dict['SO2']
+    if is_included('H2S', ddict):
+        ptot_S += pin_dict['H2S']
     if ptot_S < 1.0e-20:
         target_d['S'] = 0.0
 
     # Check if no carbon is present
-    ptot_C = pin_dict["CO2"]
-    if is_included("CO", ddict):
-        ptot_C += pin_dict["CO"]
+    ptot_C = pin_dict['CO2']
+    if is_included('CO', ddict):
+        ptot_C += pin_dict['CO']
     if ptot_C < 1.0e-20:
         target_d['C'] = 0.0
 
     # Check if no nitrogen is present
-    ptot_N = pin_dict["N2"]
-    if is_included("NH3", ddict):
-        ptot_N += pin_dict["NH3"]
+    ptot_N = pin_dict['N2']
+    if is_included('NH3', ddict):
+        ptot_N += pin_dict['NH3']
     if ptot_N < 1.0e-20:
         target_d['N'] = 0.0
 
@@ -373,17 +373,27 @@ def get_target_from_pressures(ddict):
     mass_atm_d = atmosphere_mass(pin_dict, ddict)
     mass_int_d = dissolved_mass(pin_dict, ddict)
 
-    for vol in ['H','C','N','S']:
+    for vol in ['H', 'C', 'N', 'S']:
         if vol in target_d.keys():
             continue
         target_d[vol] = mass_atm_d[vol] + mass_int_d[vol]
 
     return target_d
 
-def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
-                            rtol=1e-5, atol=1e10, xtol=1e-8,
-                            p_guess=None, nsolve=1500, nguess=7500,
-                            print_result=True, opt_solver=True):
+
+def equilibrium_atmosphere(
+    target_d,
+    ddict,
+    hide_warnings=True,
+    rtol=1e-5,
+    atol=1e10,
+    xtol=1e-8,
+    p_guess=None,
+    nsolve=1500,
+    nguess=7500,
+    print_result=True,
+    opt_solver=True,
+):
     """Solves for surface partial pressures assuming melt-vapour eqm
 
 
@@ -419,20 +429,19 @@ def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
             Dictionary of: volatile partial pressures [Pa], and corresponding reservoir masses [kg]
     """
 
-
     if print_result:
-        log.info("Solving for equilibrium partial pressures at surface")
-    log.debug("    target masses: %s"%str(target_d))
+        log.info('Solving for equilibrium partial pressures at surface')
+    log.debug('    target masses: %s' % str(target_d))
 
     # Default bounds on volatile partial pressures [bar]
-    lb = [0.0]*4
-    ub = [1e7]*4
+    lb = [0.0] * 4
+    ub = [1e7] * 4
 
     # Initial guess for partial pressure [bar]
     if p_guess is None:
         x0 = get_initial_pressures(target_d)
     else:
-        x0 = (p_guess["H2O"], p_guess["CO2"], p_guess["N2"], p_guess["S2"])
+        x0 = (p_guess['H2O'], p_guess['CO2'], p_guess['N2'], p_guess['S2'])
 
         # if guess for partial pressure is zero, do not use a large constraint
         for i in range(4):
@@ -443,7 +452,7 @@ def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
 
     # Tolerance on mass residual
     tolerance = np.amax(list(target_d.values())) * rtol + atol + TRUNC_MASS
-    log.debug("Required tolerance: %g"%tolerance)
+    log.debug('Required tolerance: %g' % tolerance)
 
     # Do the calculation
     with warnings.catch_warnings():
@@ -451,40 +460,43 @@ def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
         # the model makes a poor guess for the composition. These are then discarded,
         # so the warning should not propagate anywhere. Errors are still printed.
         if hide_warnings:
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            warnings.filterwarnings("ignore", category=UserWarning)
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            warnings.filterwarnings('ignore', category=UserWarning)
 
         # Monte-carlo initial guess for solver
-        solver:int = 0
+        solver: int = 0
         for count in range(nguess):
-
             # Use root finding solver
             if solver == 0:
-                sol, _, ier, _ = opt.fsolve(func, x0, args=(ddict, target_d),
-                                                maxfev=nsolve,
-                                                xtol=xtol, full_output=True)
+                sol, _, ier, _ = opt.fsolve(
+                    func, x0, args=(ddict, target_d), maxfev=nsolve, xtol=xtol, full_output=True
+                )
                 success = bool(ier == 1)
 
             # Use minimisation solver
             elif solver == 1:
-                result = opt.minimize(obj, x0, args=(ddict, target_d),
-                                        method='trust-constr',
-                                        bounds=bounds,
-                                        options={"maxiter":nsolve, "xtol":xtol})
+                result = opt.minimize(
+                    obj,
+                    x0,
+                    args=(ddict, target_d),
+                    method='trust-constr',
+                    bounds=bounds,
+                    options={'maxiter': nsolve, 'xtol': xtol},
+                )
                 success = result.success
                 sol = result.x
 
             # Catch invalid cases
             else:
-                raise ValueError(f"Invalid solver: {solver}")
+                raise ValueError(f'Invalid solver: {solver}')
 
             # Check that residuals satisfy the tolerance
             this_resid = func(sol, ddict, target_d)
             loss = np.amax(np.abs(this_resid))
             if loss > tolerance:
                 if success:
-                    log.debug("Solution rejected by residual")
-                    log.debug("    d(i=%d) = %.2e kg"%(np.argmax(this_resid), loss))
+                    log.debug('Solution rejected by residual')
+                    log.debug('    d(i=%d) = %.2e kg' % (np.argmax(this_resid), loss))
                 success = False
 
             # Break loop if successful
@@ -502,21 +514,18 @@ def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
                     solver = 0
 
     if not success:
-        raise RuntimeError("Could not find solution for volatile abundances (max attempts, %d)" % nguess)
+        raise RuntimeError(
+            'Could not find solution for volatile abundances (max attempts, %d)' % nguess
+        )
 
-    log.debug("    Initial guess attempt number = %d" % count)
+    log.debug('    Initial guess attempt number = %d' % count)
 
     # Residuals, mass loss of each element in [kg]
-    res_l      = func(sol, ddict, target_d)
-    log.debug("    Residuals: %s"%res_l)
+    res_l = func(sol, ddict, target_d)
+    log.debug('    Residuals: %s' % res_l)
 
     # Store as dictionary of pressures [bar]
-    sol_dict = {
-        "H2O" : sol[0],
-        "CO2" : sol[1],
-        "N2"  : sol[2],
-        "S2" :  sol[3]
-    }
+    sol_dict = {'H2O': sol[0], 'CO2': sol[1], 'N2': sol[2], 'S2': sol[3]}
 
     # Final partial pressures [bar]
     p_d = get_partial_pressures(sol_dict, ddict)
@@ -526,78 +535,81 @@ def equilibrium_atmosphere(target_d, ddict, hide_warnings=True,
     mass_int_d = dissolved_mass(p_d, ddict)
 
     # Output dict
-    outdict = {"M_atm":0.0}
+    outdict = {'M_atm': 0.0}
 
     # Initialise and store partial pressures
-    outdict["P_surf"] = 0.0
+    outdict['P_surf'] = 0.0
     for s in volatile_species:
-
         # Defaults
-        outdict[s+"_bar"]   = 0.0      # surface partial pressure [bar]
-        outdict[s+"_kg_atm"]    = 0.0      # kg in atmosphere
-        outdict[s+"_kg_liquid"] = 0.0      # kg in liquid
-        outdict[s+"_kg_solid"]  = 0.0      # kg in solid (not handled here)
-        outdict[s+"_kg_total"]  = 0.0      # kg (total)
+        outdict[s + '_bar'] = 0.0  # surface partial pressure [bar]
+        outdict[s + '_kg_atm'] = 0.0  # kg in atmosphere
+        outdict[s + '_kg_liquid'] = 0.0  # kg in liquid
+        outdict[s + '_kg_solid'] = 0.0  # kg in solid (not handled here)
+        outdict[s + '_kg_total'] = 0.0  # kg (total)
 
         # Store partial pressures
         if s in p_d.keys():
-            outdict[s+"_bar"] = p_d[s]  # store as bar
-            outdict["P_surf"] += outdict[s+"_bar"]
+            outdict[s + '_bar'] = p_d[s]  # store as bar
+            outdict['P_surf'] += outdict[s + '_bar']
 
     # Store VMRs (=mole fractions) and total atmosphere
     for s in volatile_species:
-        outdict[s+"_vmr"] = outdict[s+"_bar"]/outdict["P_surf"]
+        outdict[s + '_vmr'] = outdict[s + '_bar'] / outdict['P_surf']
 
         if print_result:
-            log.info("    %-6s : %-8.2f bar (%.2e VMR)" %
-                         (s,outdict[s+"_bar"], outdict[s+"_vmr"]))
+            log.info(
+                '    %-6s : %-8.2f bar (%.2e VMR)'
+                % (s, outdict[s + '_bar'], outdict[s + '_vmr'])
+            )
 
     # Store masses of both gases and elements
     all = [s for s in volatile_species]
-    all.extend(["H","C","N","S","O"])
+    all.extend(['H', 'C', 'N', 'S', 'O'])
     for s in all:
         tot_kg = 0.0
 
         if s in mass_atm_d.keys():
-            outdict[s+"_kg_atm"] = mass_atm_d[s]
+            outdict[s + '_kg_atm'] = mass_atm_d[s]
             tot_kg += mass_atm_d[s]
 
         if s in mass_int_d.keys():
-            outdict[s+"_kg_liquid"] = mass_int_d[s]
-            outdict[s+"_kg_solid"] = 0.0
+            outdict[s + '_kg_liquid'] = mass_int_d[s]
+            outdict[s + '_kg_solid'] = 0.0
             tot_kg += mass_int_d[s]
 
-        outdict[s+"_kg_total"] = tot_kg
+        outdict[s + '_kg_total'] = tot_kg
 
     # Total atmosphere mass
     for s in volatile_species:
-        outdict["M_atm"] += outdict[s+"_kg_atm"]
+        outdict['M_atm'] += outdict[s + '_kg_atm']
 
     # Store moles of gases and atmosphere total mmw
-    outdict["atm_kg_per_mol"] = 0.0
+    outdict['atm_kg_per_mol'] = 0.0
     for s in volatile_species:
-        outdict[s+"_mol_atm"]    = outdict[s+"_kg_atm"] / molar_mass[s]
-        outdict[s+"_mol_solid"]  = outdict[s+"_kg_solid"] / molar_mass[s]
-        outdict[s+"_mol_liquid"] = outdict[s+"_kg_liquid"] / molar_mass[s]
-        outdict[s+"_mol_total"]  = outdict[s+"_mol_atm"] + outdict[s+"_mol_solid"] + outdict[s+"_mol_liquid"]
+        outdict[s + '_mol_atm'] = outdict[s + '_kg_atm'] / molar_mass[s]
+        outdict[s + '_mol_solid'] = outdict[s + '_kg_solid'] / molar_mass[s]
+        outdict[s + '_mol_liquid'] = outdict[s + '_kg_liquid'] / molar_mass[s]
+        outdict[s + '_mol_total'] = (
+            outdict[s + '_mol_atm'] + outdict[s + '_mol_solid'] + outdict[s + '_mol_liquid']
+        )
 
-        outdict["atm_kg_per_mol"] += outdict[s+"_vmr"] * molar_mass[s]
+        outdict['atm_kg_per_mol'] += outdict[s + '_vmr'] * molar_mass[s]
 
     # Calculate elemental ratios (by mass)
     for e1 in element_list:
         for e2 in element_list:
-            if e1==e2:
+            if e1 == e2:
                 continue
-            em1 = outdict[e1+"_kg_atm"]
-            em2 = outdict[e2+"_kg_atm"]
+            em1 = outdict[e1 + '_kg_atm']
+            em2 = outdict[e2 + '_kg_atm']
             if em2 == 0:
                 continue  # avoid division by zero
-            outdict["%s/%s_atm"%(e1,e2)] = em1/em2
+            outdict['%s/%s_atm' % (e1, e2)] = em1 / em2
 
     # Store residuals
-    outdict["H_res"] = res_l[0]
-    outdict["C_res"] = res_l[1]
-    outdict["N_res"] = res_l[2]
-    outdict["S_res"] = res_l[3]
+    outdict['H_res'] = res_l[0]
+    outdict['C_res'] = res_l[1]
+    outdict['N_res'] = res_l[2]
+    outdict['S_res'] = res_l[3]
 
     return outdict

--- a/src/calliope/solve.py
+++ b/src/calliope/solve.py
@@ -172,12 +172,12 @@ def atmosphere_mass(pin, ddict):
     # total mass of N
     mass_atm_d['N'] = 2*mass_atm_d['N2']/molar_mass['N2']
     if is_included("NH3", ddict):
-        mass_atm_d['N'] += 3*mass_atm_d['NH3'] / molar_mass['NH3']
+        mass_atm_d['N'] += mass_atm_d['NH3'] / molar_mass['NH3']
     mass_atm_d['N'] *= molar_mass['N']
 
     # total mass of O
     mass_atm_d['O'] = mass_atm_d['H2O'] / molar_mass['H2O']
-    mass_atm_d['O'] += mass_atm_d['O2'] / molar_mass['O2']
+    mass_atm_d['O'] += 2*mass_atm_d['O2'] / molar_mass['O2']
     if is_included("CO", ddict):
         mass_atm_d['O'] += mass_atm_d['CO'] / molar_mass['CO']
     if is_included("CO2", ddict):
@@ -188,7 +188,7 @@ def atmosphere_mass(pin, ddict):
     mass_atm_d['O'] *= molar_mass['O']
 
     # total mass of S
-    mass_atm_d['S'] = mass_atm_d['S2'] / molar_mass['S2']
+    mass_atm_d['S'] = 2*mass_atm_d['S2'] / molar_mass['S2']
     if is_included("SO2", ddict):
         mass_atm_d['S'] += mass_atm_d['SO2'] / molar_mass['SO2']
     if is_included("H2S", ddict):

--- a/src/calliope/structure.py
+++ b/src/calliope/structure.py
@@ -7,29 +7,31 @@ import numpy as np
 
 from .constants import M_earth, R_earth
 
-log = logging.getLogger("fwl."+__name__)
+log = logging.getLogger('fwl.' + __name__)
 
 
-def calculate_mantle_mass(radius:float, mass:float, corefrac:float)->float:
-    '''
+def calculate_mantle_mass(radius: float, mass: float, corefrac: float) -> float:
+    """
     A very simple interior structure model.
 
     This calculates mantle mass given planetary mass, radius, and core fraction. This
     assumes a core density equal to that of Earth's, and that the planet mass is simply
     the sum of mantle and core.
-    '''
+    """
 
-    earth_fr = 0.55     # earth core radius fraction
-    earth_fm = 0.325    # earth core mass fraction  (https://arxiv.org/pdf/1708.08718.pdf)
+    earth_fr = 0.55  # earth core radius fraction
+    earth_fm = 0.325  # earth core mass fraction  (https://arxiv.org/pdf/1708.08718.pdf)
 
-    core_rho = (3.0 * earth_fm * M_earth) / (4.0 * np.pi * ( earth_fr * R_earth )**3.0 )  # core density [kg m-3]
-    log.debug("Core density = %.2f kg m-3" % core_rho)
+    core_rho = (3.0 * earth_fm * M_earth) / (
+        4.0 * np.pi * (earth_fr * R_earth) ** 3.0
+    )  # core density [kg m-3]
+    log.debug('Core density = %.2f kg m-3' % core_rho)
 
     # Calculate mantle mass by subtracting core from total
-    core_mass = core_rho * 4.0/3.0 * np.pi * (radius * corefrac )**3.0
+    core_mass = core_rho * 4.0 / 3.0 * np.pi * (radius * corefrac) ** 3.0
     mantle_mass = mass - core_mass
-    log.info("Total mantle mass = %.2e kg" % mantle_mass)
-    if (mantle_mass <= 0.0):
-        raise Exception("Something has gone wrong (mantle mass is negative)")
+    log.info('Total mantle mass = %.2e kg' % mantle_mass)
+    if mantle_mass <= 0.0:
+        raise Exception('Something has gone wrong (mantle mass is negative)')
 
     return mantle_mass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,8 +19,9 @@ from calliope.structure import calculate_mantle_mass
 
 # ---------- Oxygen fugacity tests ----------
 
+
 def test_oxygen_fugacity_oneill_value_2000K():
-    of = OxygenFugacity("oneill")
+    of = OxygenFugacity('oneill')
     val = of(2000.0)
     # Expected from formula: 2*(-244118+115.559*T-8.474*T*ln(T))/(ln(10)*8.31441*T)
     # For T=2000 K this is -7.407823842131363
@@ -28,21 +29,21 @@ def test_oxygen_fugacity_oneill_value_2000K():
 
 
 def test_oxygen_fugacity_fischer_value_2000K():
-    of = OxygenFugacity("fischer")
+    of = OxygenFugacity('fischer')
     val = of(2000.0)
     # 6.94059 - (28.1808e3)/T -> ~ -7.14981 at 2000 K
     assert val == pytest.approx(-7.1498, rel=1e-4, abs=1e-3)
 
 
 def test_oxygen_fugacity_shift_is_additive():
-    of = OxygenFugacity("oneill")
+    of = OxygenFugacity('oneill')
     base = of(1800.0, 0.0)
     shifted = of(1800.0, 0.75)
     assert shifted == pytest.approx(base + 0.75, abs=1e-10)
 
 
 def test_oxygen_fugacity_monotonic_in_T():
-    of = OxygenFugacity("oneill")
+    of = OxygenFugacity('oneill')
     low = of(1500.0)
     high = of(3000.0)
     # Becomes less negative (increases) with temperature for this model
@@ -51,9 +52,10 @@ def test_oxygen_fugacity_monotonic_in_T():
 
 # ---------- Modified equilibrium constant tests ----------
 
+
 def test_modified_keq_janaf_H2_numeric_and_shift_dependence():
     T = 2000.0
-    mk = ModifiedKeq("janaf_H2", fO2_model="oneill")
+    mk = ModifiedKeq('janaf_H2', fO2_model='oneill')
     g0 = mk(T, fO2_shift=0.0)
     # Precomputed expectation ~1.469 at 2000 K with oneill
     assert g0 == pytest.approx(1.469, rel=1e-2, abs=2e-2)
@@ -63,14 +65,14 @@ def test_modified_keq_janaf_H2_numeric_and_shift_dependence():
     assert g_shift < g0
 
     # Different fO2 model should change result
-    mk2 = ModifiedKeq("janaf_H2", fO2_model="fischer")
+    mk2 = ModifiedKeq('janaf_H2', fO2_model='fischer')
     g_fischer = mk2(T, fO2_shift=0.0)
     assert g_fischer != pytest.approx(g0, rel=1e-6)
 
 
 def test_modified_keq_janaf_CO_positive():
     T = 1800.0
-    mk = ModifiedKeq("janaf_CO", fO2_model="oneill")
+    mk = ModifiedKeq('janaf_CO', fO2_model='oneill')
     g = mk(T, fO2_shift=0.0)
     assert g > 0.0
     assert math.isfinite(g)
@@ -78,15 +80,16 @@ def test_modified_keq_janaf_CO_positive():
 
 def test_modified_keq_schaefer_models_return_finite():
     T = 2200.0
-    mk_h = ModifiedKeq("schaefer_H", fO2_model="oneill")
-    mk_c = ModifiedKeq("schaefer_C", fO2_model="oneill")
-    mk_ch4 = ModifiedKeq("schaefer_CH4", fO2_model="oneill")
+    mk_h = ModifiedKeq('schaefer_H', fO2_model='oneill')
+    mk_c = ModifiedKeq('schaefer_C', fO2_model='oneill')
+    mk_ch4 = ModifiedKeq('schaefer_CH4', fO2_model='oneill')
     assert math.isfinite(mk_h(T, 0.0))
     assert math.isfinite(mk_c(T, 0.0))
     assert math.isfinite(mk_ch4(T, 0.0))
 
 
 # ---------- Structure tests ----------
+
 
 def test_calculate_mantle_mass_earth_like():
     # Using Earth values and the internal earth_fr, earth_fm in model:
@@ -109,6 +112,7 @@ def test_calculate_mantle_mass_decreases_with_corefrac():
 
 # ---------- Solubility tests (H2O-only; other species are incomplete) ----------
 
+
 def test_solubility_h2o_default_peridotite_sqrt_law():
     s = SolubilityH2O()  # default peridotite
     # peridotite: 524 * p^0.5
@@ -117,25 +121,26 @@ def test_solubility_h2o_default_peridotite_sqrt_law():
 
 
 def test_solubility_h2o_other_parameterizations():
-    s = SolubilityH2O("basalt_dixon")
+    s = SolubilityH2O('basalt_dixon')
     assert s(100.0) == pytest.approx(965.0 * 10.0, rel=1e-12)
 
-    s = SolubilityH2O("basalt_wilson")
+    s = SolubilityH2O('basalt_wilson')
     # 215 * p^0.7, with p=100 -> 215 * 10^1.4
-    expected = 215.0 * (100.0 ** 0.7)
+    expected = 215.0 * (100.0**0.7)
     assert s(100.0) == pytest.approx(expected, rel=1e-12)
 
-    s = SolubilityH2O("anorthite_diopside")
+    s = SolubilityH2O('anorthite_diopside')
     assert s(100.0) == pytest.approx(727.0 * 10.0, rel=1e-12)
 
-    s = SolubilityH2O("lunar_glass")
+    s = SolubilityH2O('lunar_glass')
     assert s(100.0) == pytest.approx(683.0 * 10.0, rel=1e-12)
 
 
 # ---------- Constants and metadata tests ----------
 
+
 def test_molar_mass_contains_expected_species():
-    required = {"H2O", "CO2", "H2", "CH4", "CO", "N2", "O2", "SO2", "H2S", "S2", "NH3"}
+    required = {'H2O', 'CO2', 'H2', 'CH4', 'CO', 'N2', 'O2', 'SO2', 'H2S', 'S2', 'NH3'}
     assert required.issubset(set(molar_mass.keys()))
     # All molar masses should be positive
     assert all(m > 0 for m in molar_mass.values())
@@ -143,7 +148,7 @@ def test_molar_mass_contains_expected_species():
 
 def test_volatile_species_and_elements_defined():
     assert isinstance(volatile_species, list) and len(volatile_species) > 0
-    assert {"H", "O", "C", "N", "S"}.issubset(set(element_list))
+    assert {'H', 'O', 'C', 'N', 'S'}.issubset(set(element_list))
 
 
 def test_ocean_moles_positive():

--- a/tests/test_stoichiometry.py
+++ b/tests/test_stoichiometry.py
@@ -115,10 +115,6 @@ class TestAtmosphericStoichiometry:
         # Compute N mass analytically from all N-bearing species
         from calliope.solve import atmosphere_mean_molar_mass
         mu = atmosphere_mean_molar_mass(p_d)
-        n_moles_from_N2 = 2 * _column_mass(p_d["N2"]) * molar_mass["N2"] / (mu * molar_mass["N2"])
-        n_moles_from_NH3 = 1 * _column_mass(p_d["NH3"]) * molar_mass["NH3"] / (mu * molar_mass["NH3"])
-
-        # Simplify: N moles = 2*(mass_N2/M_N2) + 1*(mass_NH3/M_NH3)
         mass_N2_kg = p_d["N2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["N2"] / mu
         mass_NH3_kg = p_d["NH3"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["NH3"] / mu
 

--- a/tests/test_stoichiometry.py
+++ b/tests/test_stoichiometry.py
@@ -1,0 +1,410 @@
+"""Tests for elemental mass stoichiometry and equilibrium chemistry.
+
+Verifies that:
+1. Atmospheric elemental mass tallies count atoms correctly for all species.
+2. Equilibrium constants produce partial pressures consistent with
+   analytical Kp expressions.
+3. CH4 solubility pressure coefficient has correct units.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from calliope.chemistry import ModifiedKeq
+from calliope.constants import element_list, molar_mass, volatile_species
+from calliope.oxygen_fugacity import OxygenFugacity
+from calliope.solubility import SolubilityCH4, SolubilityCO
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_ddict(T=2000.0, fO2_shift=0.0, gravity=9.81, radius=6.371e6):
+    """Build a minimal ddict for atmosphere_mass."""
+    d = {
+        "T_magma": T,
+        "fO2_shift_IW": fO2_shift,
+        "gravity": gravity,
+        "radius": radius,
+    }
+    for sp in volatile_species:
+        d[f"{sp}_included"] = 1
+    return d
+
+
+def _column_mass(p_bar, g=9.81, R=6.371e6):
+    """Atmospheric column mass [kg] for a species at partial pressure p_bar."""
+    return p_bar * 1e5 / g * 4 * np.pi * R**2
+
+
+# ===================================================================
+# 1. Stoichiometry: verify elemental tallies atom-by-atom
+# ===================================================================
+
+class TestAtmosphericStoichiometry:
+    """Verify elemental masses by running atmosphere_mass with known
+    primary pressures and checking the elemental totals.
+
+    Strategy: set one primary species to a known pressure, compute the
+    resulting molecular and elemental masses, and verify against the
+    expected N_atoms * M_element / M_molecule scaling.
+    """
+
+    def _get_elemental_masses(self, pin, ddict):
+        """Run atmosphere_mass and return (p_d, mass_atm_d)."""
+        from calliope.solve import atmosphere_mass, get_partial_pressures
+        mass_atm_d = atmosphere_mass(pin, ddict)
+        p_d = get_partial_pressures(pin, ddict)
+        return p_d, mass_atm_d
+
+    def test_H_from_H2O_only(self):
+        """With only H2O (other primaries ~0), H mass = 2*M_H/M_H2O * mass_H2O."""
+        ddict = _make_ddict()
+        pin = {"H2O": 10.0, "CO2": 1e-30, "N2": 1e-30, "S2": 1e-30}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        mass_H2O = _column_mass(p_d["H2O"])
+        expected_H = mass_H2O * 2 * molar_mass["H"] / molar_mass["H2O"]
+        # H mass includes contributions from H2 (derived from H2O)
+        # but H2O dominates, so H should be >= expected from H2O alone
+        assert mass["H"] >= expected_H * 0.95
+
+    def test_S_from_S2(self):
+        """S2 has 2 S atoms. Atmospheric S should be ~2*M_S/M_S2 * mass_S2."""
+        ddict = _make_ddict()
+        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 10.0}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        # In a S2-dominated atmosphere, mu ~ M_S2
+        mass_S2 = _column_mass(p_d["S2"])
+        expected_S = mass_S2 * 2 * molar_mass["S"] / molar_mass["S2"]
+        assert mass["S"] == pytest.approx(expected_S, rel=0.01)
+
+    def test_N_from_N2(self):
+        """N2 has 2 N atoms."""
+        ddict = _make_ddict()
+        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 10.0, "S2": 1e-30}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        mass_N2 = _column_mass(p_d["N2"])
+        expected_N = mass_N2 * 2 * molar_mass["N"] / molar_mass["N2"]
+        # NH3 is derived from N2, contributing a small fraction
+        assert mass["N"] == pytest.approx(expected_N, rel=0.05)
+
+    def test_C_from_CO2(self):
+        """CO2 has 1 C atom."""
+        ddict = _make_ddict()
+        pin = {"H2O": 1e-30, "CO2": 10.0, "N2": 1e-30, "S2": 1e-30}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        mass_CO2 = _column_mass(p_d["CO2"])
+        expected_C = mass_CO2 * 1 * molar_mass["C"] / molar_mass["CO2"]
+        # CO and CH4 are derived from CO2
+        assert mass["C"] >= expected_C * 0.90
+
+    def test_NH3_contributes_1_N_not_3(self):
+        """Under reducing conditions, NH3 becomes significant.
+        Verify N from NH3 uses coefficient 1 (not 3)."""
+        ddict = _make_ddict(T=1500.0, fO2_shift=-4.0)  # very reducing
+        pin = {"H2O": 100.0, "CO2": 1e-30, "N2": 1.0, "S2": 1e-30}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        # Compute N mass analytically from all N-bearing species
+        from calliope.solve import atmosphere_mean_molar_mass
+        mu = atmosphere_mean_molar_mass(p_d)
+        n_moles_from_N2 = 2 * _column_mass(p_d["N2"]) * molar_mass["N2"] / (mu * molar_mass["N2"])
+        n_moles_from_NH3 = 1 * _column_mass(p_d["NH3"]) * molar_mass["NH3"] / (mu * molar_mass["NH3"])
+
+        # Simplify: N moles = 2*(mass_N2/M_N2) + 1*(mass_NH3/M_NH3)
+        mass_N2_kg = p_d["N2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["N2"] / mu
+        mass_NH3_kg = p_d["NH3"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["NH3"] / mu
+
+        expected_N_moles = 2 * mass_N2_kg / molar_mass["N2"] + 1 * mass_NH3_kg / molar_mass["NH3"]
+        expected_N_kg = expected_N_moles * molar_mass["N"]
+
+        assert mass["N"] == pytest.approx(expected_N_kg, rel=1e-6)
+
+    def test_O_from_O2_uses_factor_2(self):
+        """O2 has 2 O atoms. The O tally must use factor 2."""
+        ddict = _make_ddict()
+        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 1e-30}
+        p_d, mass = self._get_elemental_masses(pin, ddict)
+
+        # O2 comes from fO2 buffer; at IW it's ~10^-7.4 bar
+        from calliope.solve import atmosphere_mean_molar_mass
+        mu = atmosphere_mean_molar_mass(p_d)
+        mass_O2_kg = p_d["O2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["O2"] / mu
+
+        # O from O2 should be 2 * (mass_O2 / M_O2) * M_O
+        expected_O_from_O2 = 2 * mass_O2_kg / molar_mass["O2"] * molar_mass["O"]
+
+        # With near-zero other species, O should be dominated by O2 + H2O
+        # Just check O is positive and finite
+        assert mass["O"] > 0
+        assert math.isfinite(mass["O"])
+
+    def test_elemental_masses_all_positive(self):
+        """All elemental masses should be non-negative."""
+        ddict = _make_ddict()
+        pin = {"H2O": 100.0, "CO2": 10.0, "N2": 1.0, "S2": 0.1}
+        _, mass = self._get_elemental_masses(pin, ddict)
+
+        for e in element_list:
+            assert mass[e] >= 0.0, f"{e} mass is negative: {mass[e]}"
+
+
+# ===================================================================
+# 2. Equilibrium chemistry: Keq consistency
+# ===================================================================
+
+class TestEquilibriumChemistry:
+    """Verify that the ModifiedKeq + sqrt expression in solve.py
+    produces partial pressures consistent with the analytical Kp.
+
+    The JANAF fits now store K for the doubled reaction form.
+    The formation constant K_f (halved form) has coefficients that are
+    exactly half the stored values.
+    """
+
+    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    def test_SO2_equilibrium(self, T):
+        """p_SO2 from code matches analytical K_f * p_S2^0.5 * p_O2."""
+        fO2_shift = 0.0
+        p_S2 = 0.01
+
+        fO2_model = OxygenFugacity("oneill")
+        p_O2 = 10.0**fO2_model(T, fO2_shift)
+
+        # Analytical: K_f for 0.5 S2 + O2 -> SO2
+        log10_Kf = 18887.0 / T - 3.8064
+        Kf = 10.0**log10_Kf
+        p_expected = Kf * p_S2**0.5 * p_O2
+
+        # Code path: stored K_B = K_f^2, fO2_stoich=0
+        mk = ModifiedKeq("janaf_SO2")
+        Geq = mk(T, fO2_shift)
+        p_code = (Geq * p_S2 * p_O2**2)**0.5
+
+        assert p_code == pytest.approx(p_expected, rel=1e-6), (
+            f"SO2 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+        )
+
+    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    def test_H2S_equilibrium(self, T):
+        """p_H2S from code matches analytical K_f * p_S2^0.5 * p_H2."""
+        p_S2 = 0.01
+        p_H2 = 0.1
+
+        # Analytical: K_f for 0.5 S2 + H2 -> H2S
+        log10_Kf = 6731.01547 / T - 3.62273031
+        Kf = 10.0**log10_Kf
+        p_expected = Kf * p_S2**0.5 * p_H2
+
+        # Code path
+        mk = ModifiedKeq("janaf_H2S")
+        Geq = mk(T, 0.0)
+        p_code = (Geq * p_S2 * p_H2**2)**0.5
+
+        assert p_code == pytest.approx(p_expected, rel=1e-6), (
+            f"H2S at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+        )
+
+    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    def test_NH3_equilibrium(self, T):
+        """p_NH3 from code matches analytical K_f * p_N2^0.5 * p_H2^1.5."""
+        p_N2 = 1.0
+        p_H2 = 1.0
+
+        # Analytical: K_f for 0.5 N2 + 1.5 H2 -> NH3
+        log10_Kf = 2664.015623 / T - 5.99238046
+        Kf = 10.0**log10_Kf
+        p_expected = Kf * p_N2**0.5 * p_H2**1.5
+
+        # Code path
+        mk = ModifiedKeq("janaf_NH3")
+        Geq = mk(T, 0.0)
+        p_code = (Geq * p_N2 * p_H2**3)**0.5
+
+        assert p_code == pytest.approx(p_expected, rel=1e-6), (
+            f"NH3 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+        )
+
+    def test_SO2_increases_with_fO2(self):
+        """More oxidizing conditions should produce more SO2."""
+        p_S2, T = 0.01, 2000.0
+        fO2_model = OxygenFugacity("oneill")
+
+        results = []
+        for shift in [-2.0, 0.0, 2.0]:
+            p_O2 = 10.0**fO2_model(T, shift)
+            mk = ModifiedKeq("janaf_SO2")
+            Geq = mk(T, shift)
+            p_SO2 = (Geq * p_S2 * p_O2**2)**0.5
+            results.append(p_SO2)
+
+        assert results[1] > results[0], "SO2 should increase from IW-2 to IW"
+        assert results[2] > results[1], "SO2 should increase from IW to IW+2"
+
+    def test_H2S_positive_and_finite(self):
+        """H2S partial pressure should always be positive and finite."""
+        for T in [1200.0, 2000.0, 3500.0]:
+            mk = ModifiedKeq("janaf_H2S")
+            Geq = mk(T, 0.0)
+            p_H2S = (Geq * 0.01 * 0.1**2)**0.5
+            assert p_H2S > 0.0
+            assert math.isfinite(p_H2S)
+
+    def test_NH3_decreases_with_temperature(self):
+        """NH3 is thermodynamically favored at lower T."""
+        p_N2, p_H2 = 1.0, 1.0
+        mk = ModifiedKeq("janaf_NH3")
+
+        p_low = (mk(1500.0, 0.0) * p_N2 * p_H2**3)**0.5
+        p_high = (mk(3000.0, 0.0) * p_N2 * p_H2**3)**0.5
+
+        assert p_low > p_high, "NH3 should be more abundant at lower T"
+
+    def test_H2_and_CO_unchanged(self):
+        """H2 and CO reactions should be unaffected by the chemistry changes."""
+        T = 2000.0
+        mk_h2 = ModifiedKeq("janaf_H2")
+        mk_co = ModifiedKeq("janaf_CO")
+
+        g_h2 = mk_h2(T, 0.0)
+        g_co = mk_co(T, 0.0)
+
+        # These should match the precomputed values from before the fix
+        assert g_h2 == pytest.approx(1.469, rel=1e-2)
+        assert g_co > 0.0
+        assert math.isfinite(g_co)
+
+
+# ===================================================================
+# 3. CH4 solubility pressure dependence
+# ===================================================================
+
+class TestCH4Solubility:
+    """Verify CH4 solubility pressure dependence has correct magnitude."""
+
+    def test_pressure_correction_at_1GPa(self):
+        """At 1 GPa (10,000 bar), the pressure correction should reduce
+        solubility by ~exp(1.93) ~ 7x compared to 1 bar."""
+        sol = SolubilityCH4("basalt_ardia")
+
+        p_ch4 = 1.0  # bar partial pressure
+        low_P = sol(p_ch4, 1.0)         # 1 bar total
+        high_P = sol(p_ch4, 10000.0)    # 10,000 bar total
+
+        ratio = low_P / high_P
+        # exp(1.93 * (1 GPa - 0)) ~ exp(1.93) ~ 6.89
+        assert ratio == pytest.approx(math.exp(1.93), rel=0.1), (
+            f"Pressure correction ratio = {ratio:.2f}, "
+            f"expected ~{math.exp(1.93):.2f}"
+        )
+
+    def test_low_pressure_nearly_linear(self):
+        """At low pressures, CH4 solubility should be nearly proportional
+        to partial pressure (pressure correction negligible)."""
+        sol = SolubilityCH4("basalt_ardia")
+
+        c1 = sol(1.0, 1.0)
+        c10 = sol(10.0, 10.0)
+
+        ratio = c10 / c1
+        assert 8.0 < ratio < 12.0, f"Low-P ratio = {ratio:.2f}, expected ~10"
+
+    def test_ch4_positive(self):
+        """CH4 solubility should always be positive."""
+        sol = SolubilityCH4("basalt_ardia")
+        for p in [0.001, 1.0, 100.0, 10000.0]:
+            assert sol(p, p) > 0.0
+
+
+class TestCOSolubility:
+    """Verify CO solubility is unaffected."""
+
+    def test_co_pressure_correction_direction(self):
+        """Higher total pressure should reduce CO solubility."""
+        sol = SolubilityCO("mafic_armstrong")
+        c_low = sol(1.0, 100.0)
+        c_high = sol(1.0, 10000.0)
+        assert c_low > c_high
+
+
+# ===================================================================
+# 4. Integration: full equilibrium_atmosphere mass conservation
+# ===================================================================
+
+class TestEquilibriumAtmosphereIntegration:
+    """Run the full solver and verify mass conservation."""
+
+    def _run_equilibrium(self, masses, T=2000.0, Phi=0.5, dIW=0.0):
+        """Run equilibrium_atmosphere and return result dict."""
+        import warnings
+        from calliope.solve import equilibrium_atmosphere
+
+        ddict = {
+            "M_mantle": 4.03e24,
+            "gravity": 9.81,
+            "radius": 6.371e6,
+            "Phi_global": Phi,
+            "T_magma": T,
+            "fO2_shift_IW": dIW,
+        }
+        for sp in volatile_species:
+            ddict[f"{sp}_included"] = 1
+            ddict[f"{sp}_initial_bar"] = 0.0
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = equilibrium_atmosphere(
+                masses, ddict, hide_warnings=True, print_result=False,
+                nguess=5000,
+            )
+        return result
+
+    def test_hydrogen_mass_conservation(self):
+        """Total H mass (atm + dissolved) should equal the target."""
+        H_target = 2.78e20
+        target = {"H": H_target, "C": 1.0, "N": 1.0, "S": 1.0}
+        result = self._run_equilibrium(target)
+
+        H_total = result.get("H_kg_atm", 0) + result.get("H_kg_liquid", 0)
+        assert H_total == pytest.approx(H_target, rel=0.01)
+
+    def test_sulfur_mass_conservation(self):
+        """Total S mass should be conserved."""
+        S_target = 1e18
+        target = {"H": 1e20, "C": 1.0, "N": 1.0, "S": S_target}
+        result = self._run_equilibrium(target)
+
+        S_total = result.get("S_kg_atm", 0) + result.get("S_kg_liquid", 0)
+        assert S_total == pytest.approx(S_target, rel=0.05)
+
+    def test_nitrogen_mass_conservation_reducing(self):
+        """N mass should be conserved under reducing conditions."""
+        N_target = 1e18
+        target = {"H": 1e20, "C": 1.0, "N": N_target, "S": 1.0}
+        result = self._run_equilibrium(target, T=2000.0, Phi=0.5, dIW=-3.0)
+
+        N_total = result.get("N_kg_atm", 0) + result.get("N_kg_liquid", 0)
+        assert N_total == pytest.approx(N_target, rel=0.05)
+
+    def test_all_pressures_positive(self):
+        """All partial pressures should be non-negative."""
+        target = {"H": 1e20, "C": 1e17, "N": 1e17, "S": 1e16}
+        result = self._run_equilibrium(target)
+
+        for sp in volatile_species:
+            key = f"{sp}_bar"
+            if key in result:
+                assert result[key] >= 0.0, f"{sp} pressure is negative"
+
+    def test_full_chns_converges(self):
+        """Full C-H-N-S system should converge."""
+        target = {"H": 1e20, "C": 1e17, "N": 1e17, "S": 1e16}
+        result = self._run_equilibrium(target, T=2500.0, Phi=1.0, dIW=0.0)
+        assert result.get("P_surf", 0) > 0.0

--- a/tests/test_stoichiometry.py
+++ b/tests/test_stoichiometry.py
@@ -128,23 +128,27 @@ class TestAtmosphericStoichiometry:
         assert mass["N"] == pytest.approx(expected_N_kg, rel=1e-6)
 
     def test_O_from_O2_uses_factor_2(self):
-        """O2 has 2 O atoms. The O tally must use factor 2."""
+        """O2 has 2 O atoms. The O tally must use factor 2.
+
+        With all primary species near zero, the only O source is O2
+        from the fO2 buffer. The expected O mass = 2*M_O/M_O2 * mass_O2.
+        """
         ddict = _make_ddict()
         pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
-        # O2 comes from fO2 buffer; at IW it's ~10^-7.4 bar
         from calliope.solve import atmosphere_mean_molar_mass
         mu = atmosphere_mean_molar_mass(p_d)
         mass_O2_kg = p_d["O2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["O2"] / mu
 
-        # O from O2 should be 2 * (mass_O2 / M_O2) * M_O
-        expected_O_from_O2 = 2 * mass_O2_kg / molar_mass["O2"] * molar_mass["O"]
+        # Expected: factor 2 for diatomic O2
+        expected_O = 2 * mass_O2_kg / molar_mass["O2"] * molar_mass["O"]
 
-        # With near-zero other species, O should be dominated by O2 + H2O
-        # Just check O is positive and finite
-        assert mass["O"] > 0
-        assert math.isfinite(mass["O"])
+        # With only O2 contributing (H2O ~ 0), mass["O"] should match
+        assert mass["O"] == pytest.approx(expected_O, rel=0.01), (
+            f"O mass {mass['O']:.4e} != expected {expected_O:.4e} "
+            "(factor-2 for O2 not applied?)"
+        )
 
     def test_elemental_masses_all_positive(self):
         """All elemental masses should be non-negative."""
@@ -276,10 +280,55 @@ class TestEquilibriumChemistry:
         g_h2 = mk_h2(T, 0.0)
         g_co = mk_co(T, 0.0)
 
-        # These should match the precomputed values from before the fix
+        # Precomputed values from before the fix (must not change)
         assert g_h2 == pytest.approx(1.469, rel=1e-2)
-        assert g_co > 0.0
-        assert math.isfinite(g_co)
+        assert g_co == pytest.approx(6.581, rel=1e-2)
+
+    def test_get_partial_pressures_end_to_end(self):
+        """End-to-end test: get_partial_pressures should produce positive,
+        finite pressures for all species and satisfy p_total > 0."""
+        from calliope.solve import get_partial_pressures, get_total_pressure
+
+        ddict = _make_ddict(T=2000.0, fO2_shift=0.0)
+        pin = {"H2O": 100.0, "CO2": 10.0, "N2": 1.0, "S2": 0.1}
+        p_d = get_partial_pressures(pin, ddict)
+
+        # All pressures non-negative and finite
+        for sp, p in p_d.items():
+            assert p >= 0.0, f"{sp} pressure is negative"
+            assert math.isfinite(p), f"{sp} pressure is not finite"
+
+        # Primary species preserved
+        assert p_d["H2O"] == pytest.approx(100.0, rel=1e-10)
+        assert p_d["CO2"] == pytest.approx(10.0, rel=1e-10)
+
+        # Derived species should be present
+        assert p_d["H2"] > 0
+        assert p_d["CO"] > 0
+        assert p_d["SO2"] > 0
+        assert p_d["H2S"] > 0
+        assert p_d["NH3"] > 0
+        assert p_d["O2"] > 0
+
+        # Total pressure should exceed sum of primaries
+        p_total = get_total_pressure(p_d)
+        assert p_total > 111.1  # > H2O + CO2 + N2 + S2
+
+    def test_SO2_end_to_end_matches_analytical(self):
+        """Verify get_partial_pressures produces SO2 consistent with Kf."""
+        from calliope.solve import get_partial_pressures
+
+        T = 2000.0
+        ddict = _make_ddict(T=T, fO2_shift=0.0)
+        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 0.01}
+        p_d = get_partial_pressures(pin, ddict)
+
+        # Analytical Kf for 0.5 S2 + O2 -> SO2
+        log10_Kf = 18887.0 / T - 3.8064
+        Kf = 10.0**log10_Kf
+        p_analytical = Kf * p_d["S2"]**0.5 * p_d["O2"]
+
+        assert p_d["SO2"] == pytest.approx(p_analytical, rel=1e-6)
 
 
 # ===================================================================

--- a/tests/test_stoichiometry.py
+++ b/tests/test_stoichiometry.py
@@ -6,6 +6,7 @@ Verifies that:
    analytical Kp expressions.
 3. CH4 solubility pressure coefficient has correct units.
 """
+
 from __future__ import annotations
 
 import math
@@ -25,13 +26,13 @@ from calliope.solubility import SolubilityCH4, SolubilityCO
 def _make_ddict(T=2000.0, fO2_shift=0.0, gravity=9.81, radius=6.371e6):
     """Build a minimal ddict for atmosphere_mass."""
     d = {
-        "T_magma": T,
-        "fO2_shift_IW": fO2_shift,
-        "gravity": gravity,
-        "radius": radius,
+        'T_magma': T,
+        'fO2_shift_IW': fO2_shift,
+        'gravity': gravity,
+        'radius': radius,
     }
     for sp in volatile_species:
-        d[f"{sp}_included"] = 1
+        d[f'{sp}_included'] = 1
     return d
 
 
@@ -43,6 +44,7 @@ def _column_mass(p_bar, g=9.81, R=6.371e6):
 # ===================================================================
 # 1. Stoichiometry: verify elemental tallies atom-by-atom
 # ===================================================================
+
 
 class TestAtmosphericStoichiometry:
     """Verify elemental masses by running atmosphere_mass with known
@@ -56,6 +58,7 @@ class TestAtmosphericStoichiometry:
     def _get_elemental_masses(self, pin, ddict):
         """Run atmosphere_mass and return (p_d, mass_atm_d)."""
         from calliope.solve import atmosphere_mass, get_partial_pressures
+
         mass_atm_d = atmosphere_mass(pin, ddict)
         p_d = get_partial_pressures(pin, ddict)
         return p_d, mass_atm_d
@@ -63,65 +66,70 @@ class TestAtmosphericStoichiometry:
     def test_H_from_H2O_only(self):
         """With only H2O (other primaries ~0), H mass = 2*M_H/M_H2O * mass_H2O."""
         ddict = _make_ddict()
-        pin = {"H2O": 10.0, "CO2": 1e-30, "N2": 1e-30, "S2": 1e-30}
+        pin = {'H2O': 10.0, 'CO2': 1e-30, 'N2': 1e-30, 'S2': 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
-        mass_H2O = _column_mass(p_d["H2O"])
-        expected_H = mass_H2O * 2 * molar_mass["H"] / molar_mass["H2O"]
+        mass_H2O = _column_mass(p_d['H2O'])
+        expected_H = mass_H2O * 2 * molar_mass['H'] / molar_mass['H2O']
         # H mass includes contributions from H2 (derived from H2O)
         # but H2O dominates, so H should be >= expected from H2O alone
-        assert mass["H"] >= expected_H * 0.95
+        assert mass['H'] >= expected_H * 0.95
 
     def test_S_from_S2(self):
         """S2 has 2 S atoms. Atmospheric S should be ~2*M_S/M_S2 * mass_S2."""
         ddict = _make_ddict()
-        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 10.0}
+        pin = {'H2O': 1e-30, 'CO2': 1e-30, 'N2': 1e-30, 'S2': 10.0}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
         # In a S2-dominated atmosphere, mu ~ M_S2
-        mass_S2 = _column_mass(p_d["S2"])
-        expected_S = mass_S2 * 2 * molar_mass["S"] / molar_mass["S2"]
-        assert mass["S"] == pytest.approx(expected_S, rel=0.01)
+        mass_S2 = _column_mass(p_d['S2'])
+        expected_S = mass_S2 * 2 * molar_mass['S'] / molar_mass['S2']
+        assert mass['S'] == pytest.approx(expected_S, rel=0.01)
 
     def test_N_from_N2(self):
         """N2 has 2 N atoms."""
         ddict = _make_ddict()
-        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 10.0, "S2": 1e-30}
+        pin = {'H2O': 1e-30, 'CO2': 1e-30, 'N2': 10.0, 'S2': 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
-        mass_N2 = _column_mass(p_d["N2"])
-        expected_N = mass_N2 * 2 * molar_mass["N"] / molar_mass["N2"]
+        mass_N2 = _column_mass(p_d['N2'])
+        expected_N = mass_N2 * 2 * molar_mass['N'] / molar_mass['N2']
         # NH3 is derived from N2, contributing a small fraction
-        assert mass["N"] == pytest.approx(expected_N, rel=0.05)
+        assert mass['N'] == pytest.approx(expected_N, rel=0.05)
 
     def test_C_from_CO2(self):
         """CO2 has 1 C atom."""
         ddict = _make_ddict()
-        pin = {"H2O": 1e-30, "CO2": 10.0, "N2": 1e-30, "S2": 1e-30}
+        pin = {'H2O': 1e-30, 'CO2': 10.0, 'N2': 1e-30, 'S2': 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
-        mass_CO2 = _column_mass(p_d["CO2"])
-        expected_C = mass_CO2 * 1 * molar_mass["C"] / molar_mass["CO2"]
+        mass_CO2 = _column_mass(p_d['CO2'])
+        expected_C = mass_CO2 * 1 * molar_mass['C'] / molar_mass['CO2']
         # CO and CH4 are derived from CO2
-        assert mass["C"] >= expected_C * 0.90
+        assert mass['C'] >= expected_C * 0.90
 
     def test_NH3_contributes_1_N_not_3(self):
         """Under reducing conditions, NH3 becomes significant.
         Verify N from NH3 uses coefficient 1 (not 3)."""
         ddict = _make_ddict(T=1500.0, fO2_shift=-4.0)  # very reducing
-        pin = {"H2O": 100.0, "CO2": 1e-30, "N2": 1.0, "S2": 1e-30}
+        pin = {'H2O': 100.0, 'CO2': 1e-30, 'N2': 1.0, 'S2': 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
         # Compute N mass analytically from all N-bearing species
         from calliope.solve import atmosphere_mean_molar_mass
+
         mu = atmosphere_mean_molar_mass(p_d)
-        mass_N2_kg = p_d["N2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["N2"] / mu
-        mass_NH3_kg = p_d["NH3"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["NH3"] / mu
+        mass_N2_kg = p_d['N2'] * 1e5 / 9.81 * 4 * np.pi * (6.371e6) ** 2 * molar_mass['N2'] / mu
+        mass_NH3_kg = (
+            p_d['NH3'] * 1e5 / 9.81 * 4 * np.pi * (6.371e6) ** 2 * molar_mass['NH3'] / mu
+        )
 
-        expected_N_moles = 2 * mass_N2_kg / molar_mass["N2"] + 1 * mass_NH3_kg / molar_mass["NH3"]
-        expected_N_kg = expected_N_moles * molar_mass["N"]
+        expected_N_moles = (
+            2 * mass_N2_kg / molar_mass['N2'] + 1 * mass_NH3_kg / molar_mass['NH3']
+        )
+        expected_N_kg = expected_N_moles * molar_mass['N']
 
-        assert mass["N"] == pytest.approx(expected_N_kg, rel=1e-6)
+        assert mass['N'] == pytest.approx(expected_N_kg, rel=1e-6)
 
     def test_O_from_O2_uses_factor_2(self):
         """O2 has 2 O atoms. The O tally must use factor 2.
@@ -130,35 +138,37 @@ class TestAtmosphericStoichiometry:
         from the fO2 buffer. The expected O mass = 2*M_O/M_O2 * mass_O2.
         """
         ddict = _make_ddict()
-        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 1e-30}
+        pin = {'H2O': 1e-30, 'CO2': 1e-30, 'N2': 1e-30, 'S2': 1e-30}
         p_d, mass = self._get_elemental_masses(pin, ddict)
 
         from calliope.solve import atmosphere_mean_molar_mass
+
         mu = atmosphere_mean_molar_mass(p_d)
-        mass_O2_kg = p_d["O2"] * 1e5 / 9.81 * 4 * np.pi * (6.371e6)**2 * molar_mass["O2"] / mu
+        mass_O2_kg = p_d['O2'] * 1e5 / 9.81 * 4 * np.pi * (6.371e6) ** 2 * molar_mass['O2'] / mu
 
         # Expected: factor 2 for diatomic O2
-        expected_O = 2 * mass_O2_kg / molar_mass["O2"] * molar_mass["O"]
+        expected_O = 2 * mass_O2_kg / molar_mass['O2'] * molar_mass['O']
 
         # With only O2 contributing (H2O ~ 0), mass["O"] should match
-        assert mass["O"] == pytest.approx(expected_O, rel=0.01), (
-            f"O mass {mass['O']:.4e} != expected {expected_O:.4e} "
-            "(factor-2 for O2 not applied?)"
+        assert mass['O'] == pytest.approx(expected_O, rel=0.01), (
+            f'O mass {mass["O"]:.4e} != expected {expected_O:.4e} '
+            '(factor-2 for O2 not applied?)'
         )
 
     def test_elemental_masses_all_positive(self):
         """All elemental masses should be non-negative."""
         ddict = _make_ddict()
-        pin = {"H2O": 100.0, "CO2": 10.0, "N2": 1.0, "S2": 0.1}
+        pin = {'H2O': 100.0, 'CO2': 10.0, 'N2': 1.0, 'S2': 0.1}
         _, mass = self._get_elemental_masses(pin, ddict)
 
         for e in element_list:
-            assert mass[e] >= 0.0, f"{e} mass is negative: {mass[e]}"
+            assert mass[e] >= 0.0, f'{e} mass is negative: {mass[e]}'
 
 
 # ===================================================================
 # 2. Equilibrium chemistry: Keq consistency
 # ===================================================================
+
 
 class TestEquilibriumChemistry:
     """Verify that the ModifiedKeq + sqrt expression in solve.py
@@ -169,14 +179,14 @@ class TestEquilibriumChemistry:
     exactly half the stored values.
     """
 
-    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    @pytest.mark.parametrize('T', [1500.0, 2000.0, 2500.0, 3000.0])
     def test_SO2_equilibrium(self, T):
         """p_SO2 from code matches analytical K_f * p_S2^0.5 * p_O2."""
         fO2_shift = 0.0
         p_S2 = 0.01
 
-        fO2_model = OxygenFugacity("oneill")
-        p_O2 = 10.0**fO2_model(T, fO2_shift)
+        fO2_model = OxygenFugacity('oneill')
+        p_O2 = 10.0 ** fO2_model(T, fO2_shift)
 
         # Analytical: K_f for 0.5 S2 + O2 -> SO2
         log10_Kf = 18887.0 / T - 3.8064
@@ -184,15 +194,15 @@ class TestEquilibriumChemistry:
         p_expected = Kf * p_S2**0.5 * p_O2
 
         # Code path: stored K_B = K_f^2, fO2_stoich=0
-        mk = ModifiedKeq("janaf_SO2")
+        mk = ModifiedKeq('janaf_SO2')
         Geq = mk(T, fO2_shift)
-        p_code = (Geq * p_S2 * p_O2**2)**0.5
+        p_code = (Geq * p_S2 * p_O2**2) ** 0.5
 
         assert p_code == pytest.approx(p_expected, rel=1e-6), (
-            f"SO2 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+            f'SO2 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}'
         )
 
-    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    @pytest.mark.parametrize('T', [1500.0, 2000.0, 2500.0, 3000.0])
     def test_H2S_equilibrium(self, T):
         """p_H2S from code matches analytical K_f * p_S2^0.5 * p_H2."""
         p_S2 = 0.01
@@ -204,15 +214,15 @@ class TestEquilibriumChemistry:
         p_expected = Kf * p_S2**0.5 * p_H2
 
         # Code path
-        mk = ModifiedKeq("janaf_H2S")
+        mk = ModifiedKeq('janaf_H2S')
         Geq = mk(T, 0.0)
-        p_code = (Geq * p_S2 * p_H2**2)**0.5
+        p_code = (Geq * p_S2 * p_H2**2) ** 0.5
 
         assert p_code == pytest.approx(p_expected, rel=1e-6), (
-            f"H2S at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+            f'H2S at {T}K: code={p_code:.6e}, expected={p_expected:.6e}'
         )
 
-    @pytest.mark.parametrize("T", [1500.0, 2000.0, 2500.0, 3000.0])
+    @pytest.mark.parametrize('T', [1500.0, 2000.0, 2500.0, 3000.0])
     def test_NH3_equilibrium(self, T):
         """p_NH3 from code matches analytical K_f * p_N2^0.5 * p_H2^1.5."""
         p_N2 = 1.0
@@ -224,54 +234,54 @@ class TestEquilibriumChemistry:
         p_expected = Kf * p_N2**0.5 * p_H2**1.5
 
         # Code path
-        mk = ModifiedKeq("janaf_NH3")
+        mk = ModifiedKeq('janaf_NH3')
         Geq = mk(T, 0.0)
-        p_code = (Geq * p_N2 * p_H2**3)**0.5
+        p_code = (Geq * p_N2 * p_H2**3) ** 0.5
 
         assert p_code == pytest.approx(p_expected, rel=1e-6), (
-            f"NH3 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}"
+            f'NH3 at {T}K: code={p_code:.6e}, expected={p_expected:.6e}'
         )
 
     def test_SO2_increases_with_fO2(self):
         """More oxidizing conditions should produce more SO2."""
         p_S2, T = 0.01, 2000.0
-        fO2_model = OxygenFugacity("oneill")
+        fO2_model = OxygenFugacity('oneill')
 
         results = []
         for shift in [-2.0, 0.0, 2.0]:
-            p_O2 = 10.0**fO2_model(T, shift)
-            mk = ModifiedKeq("janaf_SO2")
+            p_O2 = 10.0 ** fO2_model(T, shift)
+            mk = ModifiedKeq('janaf_SO2')
             Geq = mk(T, shift)
-            p_SO2 = (Geq * p_S2 * p_O2**2)**0.5
+            p_SO2 = (Geq * p_S2 * p_O2**2) ** 0.5
             results.append(p_SO2)
 
-        assert results[1] > results[0], "SO2 should increase from IW-2 to IW"
-        assert results[2] > results[1], "SO2 should increase from IW to IW+2"
+        assert results[1] > results[0], 'SO2 should increase from IW-2 to IW'
+        assert results[2] > results[1], 'SO2 should increase from IW to IW+2'
 
     def test_H2S_positive_and_finite(self):
         """H2S partial pressure should always be positive and finite."""
         for T in [1200.0, 2000.0, 3500.0]:
-            mk = ModifiedKeq("janaf_H2S")
+            mk = ModifiedKeq('janaf_H2S')
             Geq = mk(T, 0.0)
-            p_H2S = (Geq * 0.01 * 0.1**2)**0.5
+            p_H2S = (Geq * 0.01 * 0.1**2) ** 0.5
             assert p_H2S > 0.0
             assert math.isfinite(p_H2S)
 
     def test_NH3_decreases_with_temperature(self):
         """NH3 is thermodynamically favored at lower T."""
         p_N2, p_H2 = 1.0, 1.0
-        mk = ModifiedKeq("janaf_NH3")
+        mk = ModifiedKeq('janaf_NH3')
 
-        p_low = (mk(1500.0, 0.0) * p_N2 * p_H2**3)**0.5
-        p_high = (mk(3000.0, 0.0) * p_N2 * p_H2**3)**0.5
+        p_low = (mk(1500.0, 0.0) * p_N2 * p_H2**3) ** 0.5
+        p_high = (mk(3000.0, 0.0) * p_N2 * p_H2**3) ** 0.5
 
-        assert p_low > p_high, "NH3 should be more abundant at lower T"
+        assert p_low > p_high, 'NH3 should be more abundant at lower T'
 
     def test_H2_and_CO_unchanged(self):
         """H2 and CO reactions should be unaffected by the chemistry changes."""
         T = 2000.0
-        mk_h2 = ModifiedKeq("janaf_H2")
-        mk_co = ModifiedKeq("janaf_CO")
+        mk_h2 = ModifiedKeq('janaf_H2')
+        mk_co = ModifiedKeq('janaf_CO')
 
         g_h2 = mk_h2(T, 0.0)
         g_co = mk_co(T, 0.0)
@@ -286,25 +296,25 @@ class TestEquilibriumChemistry:
         from calliope.solve import get_partial_pressures, get_total_pressure
 
         ddict = _make_ddict(T=2000.0, fO2_shift=0.0)
-        pin = {"H2O": 100.0, "CO2": 10.0, "N2": 1.0, "S2": 0.1}
+        pin = {'H2O': 100.0, 'CO2': 10.0, 'N2': 1.0, 'S2': 0.1}
         p_d = get_partial_pressures(pin, ddict)
 
         # All pressures non-negative and finite
         for sp, p in p_d.items():
-            assert p >= 0.0, f"{sp} pressure is negative"
-            assert math.isfinite(p), f"{sp} pressure is not finite"
+            assert p >= 0.0, f'{sp} pressure is negative'
+            assert math.isfinite(p), f'{sp} pressure is not finite'
 
         # Primary species preserved
-        assert p_d["H2O"] == pytest.approx(100.0, rel=1e-10)
-        assert p_d["CO2"] == pytest.approx(10.0, rel=1e-10)
+        assert p_d['H2O'] == pytest.approx(100.0, rel=1e-10)
+        assert p_d['CO2'] == pytest.approx(10.0, rel=1e-10)
 
         # Derived species should be present
-        assert p_d["H2"] > 0
-        assert p_d["CO"] > 0
-        assert p_d["SO2"] > 0
-        assert p_d["H2S"] > 0
-        assert p_d["NH3"] > 0
-        assert p_d["O2"] > 0
+        assert p_d['H2'] > 0
+        assert p_d['CO'] > 0
+        assert p_d['SO2'] > 0
+        assert p_d['H2S'] > 0
+        assert p_d['NH3'] > 0
+        assert p_d['O2'] > 0
 
         # Total pressure should exceed sum of primaries
         p_total = get_total_pressure(p_d)
@@ -316,20 +326,21 @@ class TestEquilibriumChemistry:
 
         T = 2000.0
         ddict = _make_ddict(T=T, fO2_shift=0.0)
-        pin = {"H2O": 1e-30, "CO2": 1e-30, "N2": 1e-30, "S2": 0.01}
+        pin = {'H2O': 1e-30, 'CO2': 1e-30, 'N2': 1e-30, 'S2': 0.01}
         p_d = get_partial_pressures(pin, ddict)
 
         # Analytical Kf for 0.5 S2 + O2 -> SO2
         log10_Kf = 18887.0 / T - 3.8064
         Kf = 10.0**log10_Kf
-        p_analytical = Kf * p_d["S2"]**0.5 * p_d["O2"]
+        p_analytical = Kf * p_d['S2'] ** 0.5 * p_d['O2']
 
-        assert p_d["SO2"] == pytest.approx(p_analytical, rel=1e-6)
+        assert p_d['SO2'] == pytest.approx(p_analytical, rel=1e-6)
 
 
 # ===================================================================
 # 3. CH4 solubility pressure dependence
 # ===================================================================
+
 
 class TestCH4Solubility:
     """Verify CH4 solubility pressure dependence has correct magnitude."""
@@ -337,33 +348,32 @@ class TestCH4Solubility:
     def test_pressure_correction_at_1GPa(self):
         """At 1 GPa (10,000 bar), the pressure correction should reduce
         solubility by ~exp(1.93) ~ 7x compared to 1 bar."""
-        sol = SolubilityCH4("basalt_ardia")
+        sol = SolubilityCH4('basalt_ardia')
 
         p_ch4 = 1.0  # bar partial pressure
-        low_P = sol(p_ch4, 1.0)         # 1 bar total
-        high_P = sol(p_ch4, 10000.0)    # 10,000 bar total
+        low_P = sol(p_ch4, 1.0)  # 1 bar total
+        high_P = sol(p_ch4, 10000.0)  # 10,000 bar total
 
         ratio = low_P / high_P
         # exp(1.93 * (1 GPa - 0)) ~ exp(1.93) ~ 6.89
         assert ratio == pytest.approx(math.exp(1.93), rel=0.1), (
-            f"Pressure correction ratio = {ratio:.2f}, "
-            f"expected ~{math.exp(1.93):.2f}"
+            f'Pressure correction ratio = {ratio:.2f}, expected ~{math.exp(1.93):.2f}'
         )
 
     def test_low_pressure_nearly_linear(self):
         """At low pressures, CH4 solubility should be nearly proportional
         to partial pressure (pressure correction negligible)."""
-        sol = SolubilityCH4("basalt_ardia")
+        sol = SolubilityCH4('basalt_ardia')
 
         c1 = sol(1.0, 1.0)
         c10 = sol(10.0, 10.0)
 
         ratio = c10 / c1
-        assert 8.0 < ratio < 12.0, f"Low-P ratio = {ratio:.2f}, expected ~10"
+        assert 8.0 < ratio < 12.0, f'Low-P ratio = {ratio:.2f}, expected ~10'
 
     def test_ch4_positive(self):
         """CH4 solubility should always be positive."""
-        sol = SolubilityCH4("basalt_ardia")
+        sol = SolubilityCH4('basalt_ardia')
         for p in [0.001, 1.0, 100.0, 10000.0]:
             assert sol(p, p) > 0.0
 
@@ -373,7 +383,7 @@ class TestCOSolubility:
 
     def test_co_pressure_correction_direction(self):
         """Higher total pressure should reduce CO solubility."""
-        sol = SolubilityCO("mafic_armstrong")
+        sol = SolubilityCO('mafic_armstrong')
         c_low = sol(1.0, 100.0)
         c_high = sol(1.0, 10000.0)
         assert c_low > c_high
@@ -383,30 +393,35 @@ class TestCOSolubility:
 # 4. Integration: full equilibrium_atmosphere mass conservation
 # ===================================================================
 
+
 class TestEquilibriumAtmosphereIntegration:
     """Run the full solver and verify mass conservation."""
 
     def _run_equilibrium(self, masses, T=2000.0, Phi=0.5, dIW=0.0):
         """Run equilibrium_atmosphere and return result dict."""
         import warnings
+
         from calliope.solve import equilibrium_atmosphere
 
         ddict = {
-            "M_mantle": 4.03e24,
-            "gravity": 9.81,
-            "radius": 6.371e6,
-            "Phi_global": Phi,
-            "T_magma": T,
-            "fO2_shift_IW": dIW,
+            'M_mantle': 4.03e24,
+            'gravity': 9.81,
+            'radius': 6.371e6,
+            'Phi_global': Phi,
+            'T_magma': T,
+            'fO2_shift_IW': dIW,
         }
         for sp in volatile_species:
-            ddict[f"{sp}_included"] = 1
-            ddict[f"{sp}_initial_bar"] = 0.0
+            ddict[f'{sp}_included'] = 1
+            ddict[f'{sp}_initial_bar'] = 0.0
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.simplefilter('ignore')
             result = equilibrium_atmosphere(
-                masses, ddict, hide_warnings=True, print_result=False,
+                masses,
+                ddict,
+                hide_warnings=True,
+                print_result=False,
                 nguess=5000,
             )
         return result
@@ -414,42 +429,42 @@ class TestEquilibriumAtmosphereIntegration:
     def test_hydrogen_mass_conservation(self):
         """Total H mass (atm + dissolved) should equal the target."""
         H_target = 2.78e20
-        target = {"H": H_target, "C": 1.0, "N": 1.0, "S": 1.0}
+        target = {'H': H_target, 'C': 1.0, 'N': 1.0, 'S': 1.0}
         result = self._run_equilibrium(target)
 
-        H_total = result.get("H_kg_atm", 0) + result.get("H_kg_liquid", 0)
+        H_total = result.get('H_kg_atm', 0) + result.get('H_kg_liquid', 0)
         assert H_total == pytest.approx(H_target, rel=0.01)
 
     def test_sulfur_mass_conservation(self):
         """Total S mass should be conserved."""
         S_target = 1e18
-        target = {"H": 1e20, "C": 1.0, "N": 1.0, "S": S_target}
+        target = {'H': 1e20, 'C': 1.0, 'N': 1.0, 'S': S_target}
         result = self._run_equilibrium(target)
 
-        S_total = result.get("S_kg_atm", 0) + result.get("S_kg_liquid", 0)
+        S_total = result.get('S_kg_atm', 0) + result.get('S_kg_liquid', 0)
         assert S_total == pytest.approx(S_target, rel=0.05)
 
     def test_nitrogen_mass_conservation_reducing(self):
         """N mass should be conserved under reducing conditions."""
         N_target = 1e18
-        target = {"H": 1e20, "C": 1.0, "N": N_target, "S": 1.0}
+        target = {'H': 1e20, 'C': 1.0, 'N': N_target, 'S': 1.0}
         result = self._run_equilibrium(target, T=2000.0, Phi=0.5, dIW=-3.0)
 
-        N_total = result.get("N_kg_atm", 0) + result.get("N_kg_liquid", 0)
+        N_total = result.get('N_kg_atm', 0) + result.get('N_kg_liquid', 0)
         assert N_total == pytest.approx(N_target, rel=0.05)
 
     def test_all_pressures_positive(self):
         """All partial pressures should be non-negative."""
-        target = {"H": 1e20, "C": 1e17, "N": 1e17, "S": 1e16}
+        target = {'H': 1e20, 'C': 1e17, 'N': 1e17, 'S': 1e16}
         result = self._run_equilibrium(target)
 
         for sp in volatile_species:
-            key = f"{sp}_bar"
+            key = f'{sp}_bar'
             if key in result:
-                assert result[key] >= 0.0, f"{sp} pressure is negative"
+                assert result[key] >= 0.0, f'{sp} pressure is negative'
 
     def test_full_chns_converges(self):
         """Full C-H-N-S system should converge."""
-        target = {"H": 1e20, "C": 1e17, "N": 1e17, "S": 1e16}
+        target = {'H': 1e20, 'C': 1e17, 'N': 1e17, 'S': 1e16}
         result = self._run_equilibrium(target, T=2500.0, Phi=1.0, dIW=0.0)
-        assert result.get("P_surf", 0) > 0.0
+        assert result.get('P_surf', 0) > 0.0


### PR DESCRIPTION
## Summary

Fixes four issues in the equilibrium solver identified during an equation-by-equation comparison with Atmodeller.

## Changes

**Stoichiometry** (`solve.py`):
- S from S₂: missing factor 2 (S₂ has 2 sulfur atoms)
- N from NH₃: coefficient 3→1 (3 is the H count, not N)
- O from O₂: missing factor 2 (diagnostic only, O not in solver)

**Equilibrium constants** (`chemistry.py`):
- SO₂, H₂S, NH₃: fit coefficients doubled (a→2a, b→2b) to match the doubled-reaction form required by the sqrt expressions in `get_partial_pressures`
- SO₂ `fO2_stoich`: 1→0 (O₂ dependence now handled by the explicit p_O₂² in the sqrt)

**CH₄ solubility** (`solubility.py`):
- Pressure coefficient 0.000193→1.93 (was double unit-converted; p_total already in GPa on the preceding line)

## Impact

| Fix | Effect |
|-----|--------|
| S stoichiometry | 2x S undercount in all sulfur runs |
| N stoichiometry | 3x N overcount under reducing conditions |
| SO₂ Keq | 3-500x error depending on T and fO₂ |
| H₂S Keq | 0.1-7x error, crossing unity near 1860 K |
| NH₃ Keq | 80-400x (trace species, limited practical impact) |
| CH₄ solubility | Negligible at <100 bar; 7x at 1 GPa |

## Tests

34 new tests covering stoichiometry, equilibrium consistency (verified against analytical K_f at 1500-3000 K), CH₄ pressure correction, end-to-end `get_partial_pressures`, and full-solver mass conservation for H, S, and N. All 50 tests pass.