### PR TITLE
Publish CALLIOPE test-count badges from CI

### DIFF
--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -1,0 +1,166 @@
+name: Refresh test count badges
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/**'
+      - 'src/calliope/**'
+      - 'pyproject.toml'
+      - 'tools/generate_test_badges.py'
+      - '.github/workflows/publish-test-badges.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: badges-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-badges:
+    name: Regenerate tests-{total,unit,integration}.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Guard against publishing from a non-main ref
+        # The push trigger is already main-only, but workflow_dispatch can
+        # be launched from any branch. Publishing another ref's test count
+        # to the public badge would be misleading, so refuse it loudly.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CALLIOPE and pytest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[develop]"
+
+      - name: Regenerate badge JSON files
+        run: |
+          python tools/generate_test_badges.py --out badge_payload/
+
+      - name: Publish badges to the badges branch
+        # The ``main`` ruleset blocks direct pushes, so the badge JSON is
+        # published to a dedicated ``badges`` branch that lives outside that
+        # ruleset rather than committed back onto ``main``. shields.io reads
+        # the JSON from the raw URL of this branch. The branch carries only
+        # the JSON files plus a README; consumers that need the source tree
+        # use ``main``. The test workflow triggers only on ``main``, and the
+        # commit is marked ``[skip ci]``, so a badge refresh never starts a
+        # test run against the source-less tree.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          payload="${GITHUB_WORKSPACE}/badge_payload"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          branch="badges"
+
+          # Refuse to publish a partial or malformed set: a generator
+          # regression that drops a file or emits invalid JSON would
+          # otherwise leave a badge silently stale or broken behind a green
+          # check. Validate names and shields schema before touching the
+          # remote.
+          python - "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = Path(sys.argv[1])
+          expected = ('tests-total.json', 'tests-unit.json', 'tests-integration.json')
+          for name in expected:
+              path = payload / name
+              if not path.is_file():
+                  sys.exit(f'Missing badge file: {path}')
+              data = json.loads(path.read_text())
+              if data.get('schemaVersion') != 1 or not str(data.get('message', '')).strip():
+                  sys.exit(f'Malformed badge file: {path}')
+          print(f'Validated {len(expected)} badge file(s).')
+          PY
+
+          # Each fallible step returns explicitly: the function is invoked
+          # from a conditional, which disables ``set -e`` inside it, so a
+          # failure must be propagated by hand rather than relied on to
+          # abort. Returns 0 on a successful push or a no-op, 1 on a
+          # retryable failure.
+          attempt_publish() {
+            local work exists rc
+
+            # Tell "branch absent" (ls-remote exit 2) apart from an
+            # unreachable remote (network/auth, other non-zero), so a
+            # transient failure is retried instead of being mistaken for an
+            # empty branch and overwritten with a root commit.
+            if git ls-remote --exit-code --heads "${remote}" "${branch}" >/dev/null 2>&1; then
+              exists=1
+            else
+              rc=$?
+              if [ "${rc}" -eq 2 ]; then
+                exists=0
+              else
+                echo "Could not reach the remote to check ${branch} (rc=${rc})." >&2
+                return 1
+              fi
+            fi
+
+            work="$(mktemp -d)" || return 1
+            cd "${work}" || return 1
+            git init -q || return 1
+
+            if [ "${exists}" -eq 1 ]; then
+              git fetch -q "${remote}" "${branch}" || return 1
+              git checkout -q FETCH_HEAD || return 1
+              # Drop everything the branch carried so the new commit holds
+              # only the freshly generated files; a stale leftover would
+              # otherwise survive the checkout-and-overwrite.
+              git rm -rfq --ignore-unmatch . >/dev/null 2>&1 || return 1
+            fi
+
+            cp "${payload}"/tests-*.json . || return 1
+            printf '%s\n' \
+              '# Test count badges' \
+              '' \
+              'Machine-generated by the `Refresh test count badges` workflow that runs on `main`.' \
+              'shields.io endpoint badges read these JSON files by raw URL.' \
+              'Do not edit or delete this branch by hand; the source lives on `main`.' \
+              > README.md || return 1
+            git add tests-*.json README.md || return 1
+
+            if [ "${exists}" -eq 1 ] && git diff --cached --quiet; then
+              echo "Badge counts unchanged; nothing to publish."
+              return 0
+            fi
+
+            git -c user.name="actions" -c user.email="actions@github.com" \
+              commit -qm "Update test count badges [skip ci]" || return 1
+            git push -q "${remote}" "HEAD:refs/heads/${branch}" || return 1
+            echo "Published refreshed badges to the ${branch} branch."
+            return 0
+          }
+
+          # The concurrency group serialises runs on ``main``, so a competing
+          # run cannot move the branch tip mid-push; the retry only covers a
+          # transient network or fetch hiccup. Each attempt re-checks the
+          # branch state from a clean working tree.
+          for attempt in 1 2 3; do
+            if attempt_publish; then
+              exit 0
+            fi
+            echo "Publish attempt ${attempt} failed; retrying."
+            sleep 2
+          done
+          echo "Failed to publish badges after 3 attempts." >&2
+          exit 1

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -3,7 +3,9 @@
 [![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/CALLIOPE?label=coverage&logo=codecov&color=brightgreen)](https://app.codecov.io/gh/FormingWorlds/CALLIOPE)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/CALLIOPE/tests.yaml?branch=main&label=Unit%20Tests&color=brightgreen)](https://github.com/FormingWorlds/CALLIOPE/actions/workflows/tests.yaml)
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/CALLIOPE/nightly.yml?branch=main&label=Integration%20Tests&color=brightgreen)](https://github.com/FormingWorlds/CALLIOPE/actions/workflows/nightly.yml)
-[![tests](https://img.shields.io/endpoint?url=https://proteus-framework.org/CALLIOPE/badges/tests-total.json)](https://proteus-framework.org/testing)
+[![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/CALLIOPE/badges/tests-total.json)](https://proteus-framework.org/testing)
+[![unit tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/CALLIOPE/badges/tests-unit.json)](https://proteus-framework.org/testing)
+[![integration tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/CALLIOPE/badges/tests-integration.json)](https://proteus-framework.org/testing)
 
 Tests verify that the code does what was written; physical correctness is judged by data, not by tests.
 The suite catches regressions in equilibrium chemistry, solubility laws, oxygen-fugacity buffers, and the hybrid solver, but it cannot certify that those formulae match nature.
@@ -180,13 +182,13 @@ python tools/check_test_quality.py --physics-invariant-status
 ## Public-facing badges versus internal taxonomy
 
 Public-facing badges (README, project website) collapse `smoke + integration + slow` into a single `Integration Tests` category, because a four-way taxonomy is confusing to non-developer readers.
-The four-marker internal scheme remains for CI infrastructure granularity: the PR gate runs `(unit or smoke)`, the nightly runs everything, and the test-count badge fetches the JSON files written into the documentation site during the docs deploy.
+The four-marker internal scheme remains for CI infrastructure granularity: the PR gate runs `(unit or smoke)`, the nightly runs everything, and the test-count badge reads the JSON files published on the repository's `badges` branch.
 
 ## Badge system
 
-The documentation deploy (`.github/workflows/docs.yaml`) regenerates three JSON files, `tests-{total,unit,integration}.json`, from `pytest --collect-only` and writes them into the published site under `badges/`.
-Shields.io fetches them live from the site via the endpoint URL embedded in the test-count badge.
-The counts refresh on every documentation build, so they track the suite without running it.
+The `Refresh test count badges` workflow (`.github/workflows/publish-test-badges.yml`) regenerates three JSON files, `tests-{total,unit,integration}.json`, from `pytest --collect-only` and publishes them to the root of a dedicated `badges` branch.
+The `main` branch requires review for direct pushes, so the badge JSON lives on that separate branch, which shields.io reads by raw URL.
+The counts refresh whenever the test suite or source changes on `main`, so they track the suite without running it.
 
 ## Coverage gates
 

--- a/docs/How-to/build_tests.md
+++ b/docs/How-to/build_tests.md
@@ -3,7 +3,7 @@
 [![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/CALLIOPE?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/CALLIOPE)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/CALLIOPE/tests.yaml?branch=main&label=Unit%20Tests)](https://github.com/FormingWorlds/CALLIOPE/actions/workflows/tests.yaml)
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/CALLIOPE/nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/CALLIOPE/actions/workflows/nightly.yml)
-[![tests](https://img.shields.io/endpoint?url=https://proteus-framework.org/CALLIOPE/badges/tests-total.json)](https://proteus-framework.org/testing)
+[![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/CALLIOPE/badges/tests-total.json)](https://proteus-framework.org/testing)
 
 This page is the practical contributor guide for adding or modifying a test in CALLIOPE.
 The conceptual framing (marker scheme, badge system, coverage gates, AST linter) lives in the [testing suite](../Explanations/testing.md) explainer; read it first if you have not yet.

--- a/tools/generate_test_badges.py
+++ b/tools/generate_test_badges.py
@@ -81,7 +81,7 @@ def count_tests(marker_expr: str) -> int:
         trailing summary line cannot be parsed from stdout.
     """
     proc = subprocess.run(
-        ['pytest', '--collect-only', '-q', '-m', marker_expr],
+        [sys.executable, '-m', 'pytest', '--collect-only', '-q', '-m', marker_expr],
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Description

Publish CALLIOPE's test-count badges from CI to a dedicated `badges` branch, so the docs testing page and the central testing dashboard read a live count. CALLIOPE already had the generator and the testing page, but the central dashboard reads the badges-branch raw URL, which did not exist, so its row was broken. This adds the publish workflow, points the docs at the `badges` branch, and hardens the generator to run pytest through the current interpreter.

## Validation of changes

- Generator dry-run and pre-seeded `badges` branch: total 364, unit 223, integration 141; all three raw endpoints (`raw.githubusercontent.com/FormingWorlds/CALLIOPE/badges/tests-{total,unit,integration}.json`) return 200 valid JSON.
- Collection runs clean under `pip install .[develop]` (the atmodeller and hypothesis importorskips do not drop the count).

Test configuration: ubuntu-latest, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/CALLIOPE/Community/CONTRIBUTING.html)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
