### PR TITLE
Fail the tests when a pre-commit exclusion stops matching

### DIFF
--- a/.github/.claude/rules/calliope-tests.md
+++ b/.github/.claude/rules/calliope-tests.md
@@ -307,8 +307,9 @@ Write the OUTCOME (what the test verifies; what the PR achieves) never the PROCE
 - Test names describe behavior, not the called function: `test_iw_buffer_monotonic_with_temperature`, NOT `test_iw_buffer`.
 - Test names use snake_case and read as full sentences.
 - Group related tests in classes (`class TestIWBuffer:`) when they share setup; use the class to thread a single fixture through several scenarios.
-- Test file names mirror source 1:1: `src/calliope/<file>.py` -> `tests/test_<file>.py`. Two documented exceptions to the 1:1 rule:
+- Test file names mirror source 1:1: `src/calliope/<file>.py` -> `tests/test_<file>.py`. Three documented exceptions to the 1:1 rule:
   - **Cross-cutting fuzz / init tests** (`test_invariants_hypothesis.py`, `test_init.py`): tests that span multiple source files or test package-level concerns.
+  - **Repository-configuration tests** (`test_precommit_config.py`): tests that hold a checked-in configuration file to an invariant rather than exercising a source file.
   - **Topical sub-files of a large physics source**: when a physics source exceeds ~500 LOC and its tests split into independent topics that would not benefit from consolidation, topical sub-files are acceptable alongside the primary `tests/test_<file>.py`. The primary file must still exist and carry at least one `reference_pinned` and one `physics_invariant` test; the topical sub-files cover the remaining surface. The current exemption is `solve.py` (>1200 LOC), whose tests split across `test_authoritative_O.py`, `test_equilibrium_paths.py`, `test_partial_species.py`, `test_stoichiometry.py`, `test_targets.py`, `test_invariants.py`. The primary `tests/test_solve.py` carries the round-trip self-consistency anchor.
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,7 +146,7 @@ pre-commit install -f
   - `solve.py` - Root-finder, equilibrium-atmosphere solver, authoritative-O entry (physics)
   - `structure.py` - Interior structure: mantle-mass closure from Zeng+2016 core fraction (physics)
 
-- `tests/` - Test suite. Each physics source has a 1:1 test file at `tests/test_<file>.py`. Cross-cutting tests (`test_invariants_hypothesis.py`, `test_init.py`) are the exception.
+- `tests/` - Test suite. Each physics source has a 1:1 test file at `tests/test_<file>.py`. Cross-cutting tests (`test_invariants_hypothesis.py`, `test_init.py`) and the repository-configuration test (`test_precommit_config.py`) are the exception.
 
 - `tools/` - Build / utility scripts
   - `check_test_quality.py` - AST linter (blocking on PRs)
@@ -184,7 +184,7 @@ CALLIOPE is scientific simulation code, so the test suite is held to physics-gra
 
 ### Structure
 
-- Tests mirror source 1:1: `src/calliope/<file>.py` -> `tests/test_<file>.py`. Cross-cutting tests (`test_invariants_hypothesis.py`, `test_init.py`) are the exception, not the rule.
+- Tests mirror source 1:1: `src/calliope/<file>.py` -> `tests/test_<file>.py`. Cross-cutting tests (`test_invariants_hypothesis.py`, `test_init.py`) and the repository-configuration test (`test_precommit_config.py`) are the exception, not the rule.
 - Framework: `pytest` exclusively in the `tests/` directory.
 
 ### Markers and the module-level marker rule

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     hooks:
       # The vendored SIL Open Font License text is redistributed verbatim
       # alongside the fonts, so the two rewriting hooks leave it alone.
+      # A test asserts that each exclude below still matches a tracked file.
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude: ^docs/stylesheets/fonts/OFL\.txt$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       # The vendored SIL Open Font License text is redistributed verbatim
       # alongside the fonts, so the two rewriting hooks leave it alone.
-      # A test asserts that each exclude below still matches a tracked file.
+      # A test asserts that every exclude in this file matches a tracked file.
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude: ^docs/stylesheets/fonts/OFL\.txt$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ develop = [
     "pytest >= 8.1",
     "pytest-cov",
     "pre-commit",
+    "pyyaml",
     "ruff",
 ]
 

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -1,0 +1,151 @@
+"""Tests for the hook exclusions declared in `.pre-commit-config.yaml`.
+
+Exercises the one property that pre-commit itself does not check on an ordinary
+run: an `exclude` regex that stops matching any file is not an error, it is a
+silent no-op. The excluded file quietly rejoins the set the rewriting hooks act
+on, and the next contributor sees the style check go red for a reason that looks
+unrelated to the path change that caused it.
+
+Scope of the check. Every `exclude` in the config, both the config-level one and
+each hook's own, must match at least one file from `git ls-files`. That file set
+is a superset of what any single hook inspects, because the check does not narrow
+by a hook's `files`, `types`, `types_or` or `exclude_types` the way pre-commit
+does when it selects work. The check is therefore one-sided: it never fires
+merely because a hook would have filtered a match out by type, and it does not
+catch an exclusion that is dead only within one hook's narrower file set.
+
+The check also requires the config to declare at least one exclusion, so it
+cannot pass by having nothing left to inspect. Removing the last exclusion from
+the config means removing this file along with it.
+
+The sibling ecosystem repositories carry the same file; keep the copies in step.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / '.pre-commit-config.yaml'
+
+# pre-commit's own "match nothing" pattern, and the value it applies to any hook
+# that declares no exclusion. Matching nothing is what it is for, so it is never
+# a stale pattern.
+NULL_EXCLUDE = '^$'
+
+
+def _declared_excludes(config):
+    """Yield `(label, pattern)` for the config-level and per-hook exclusions."""
+    candidates = [('<config>', config.get('exclude'))]
+    for repo in config.get('repos') or ():
+        for hook in repo.get('hooks') or ():
+            candidates.append((hook.get('id', '<unnamed hook>'), hook.get('exclude')))
+    for label, pattern in candidates:
+        if pattern and pattern != NULL_EXCLUDE:
+            yield label, pattern
+
+
+def _stale_excludes(config, files):
+    """Return `(label, pattern)` for every exclusion matching none of `files`.
+
+    pre-commit selects files with `re.search`, not `re.match`, so the same call
+    is used here to keep the two in agreement.
+    """
+    stale = []
+    for label, pattern in _declared_excludes(config):
+        regex = re.compile(pattern)
+        if not any(regex.search(name) for name in files):
+            stale.append((label, pattern))
+    return stale
+
+
+def _tracked_files():
+    """Return the repository's tracked paths, or None when git cannot be run."""
+    if shutil.which('git') is None:
+        return None
+    try:
+        completed = subprocess.run(
+            ['git', 'ls-files', '-z'],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            # Pinned rather than left to the locale, so a non-ASCII path under a
+            # C locale yields surrogates instead of raising mid-call.
+            encoding='utf-8',
+            errors='surrogateescape',
+            timeout=30,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return [name for name in completed.stdout.split('\0') if name]
+
+
+def test_every_exclude_matches_a_tracked_file():
+    """Every exclusion in the pre-commit config still applies to a real file.
+
+    An exclusion that matches nothing has stopped protecting whatever it was
+    written for, most often because the file moved or was renamed, and
+    pre-commit reports no error when that happens.
+    """
+    files = _tracked_files()
+    if files is None:
+        pytest.skip('git unavailable, cannot enumerate tracked files')
+
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding='utf-8'))
+    declared = list(_declared_excludes(config))
+    # Without this the test would pass vacuously on a config that had lost its
+    # exclusions altogether, which is the very state being guarded.
+    assert declared, f'{CONFIG_PATH.name} declares no exclude'
+
+    stale = _stale_excludes(config, files)
+    assert not stale, 'exclude matches no tracked file: ' + ', '.join(
+        f'{label} -> {pattern}' for label, pattern in stale
+    )
+
+
+def test_stale_exclude_is_reported():
+    """A dead exclusion is reported while live ones beside it are not.
+
+    Models the realistic break: the vendored font assets move to a new
+    directory and one hook's regex is left pointing at the old path. The
+    config-level exclusion and the match-nothing pattern are both in the
+    fixture so that neither is mistaken for a stale one.
+    """
+    files = ['docs/stylesheets/fonts/OFL.txt', 'README.md']
+    config = {
+        'exclude': r'^docs/stylesheets/',
+        'repos': [
+            {
+                'hooks': [
+                    {
+                        'id': 'trailing-whitespace',
+                        'exclude': r'^docs/stylesheets/fonts/OFL\.txt$',
+                    },
+                    {
+                        'id': 'end-of-file-fixer',
+                        'exclude': r'^docs/assets/fonts/OFL\.txt$',
+                    },
+                    {'id': 'ruff', 'exclude': NULL_EXCLUDE},
+                ]
+            }
+        ],
+    }
+
+    stale = _stale_excludes(config, files)
+    assert stale == [('end-of-file-fixer', r'^docs/assets/fonts/OFL\.txt$')]
+    # The surviving exclusions must stay out of the report, so the check
+    # discriminates on the regex rather than flagging every hook it sees.
+    assert {label for label, _ in stale} == {'end-of-file-fixer'}
+
+    # A config-level exclusion is checked too, and goes stale the same way.
+    config['exclude'] = r'^docs/assets/'
+    assert ('<config>', r'^docs/assets/') in _stale_excludes(config, files)

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -18,7 +18,9 @@ The check also requires the config to declare at least one exclusion, so it
 cannot pass by having nothing left to inspect. Removing the last exclusion from
 the config means removing this file along with it.
 
-The sibling ecosystem repositories carry the same file; keep the copies in step.
+The CALLIOPE and MORS repositories keep this file identical, since both vendor
+the same font assets behind the same exclusions. A change to one belongs in the
+other.
 """
 
 from __future__ import annotations
@@ -134,6 +136,10 @@ def test_stale_exclude_is_reported():
                         'id': 'end-of-file-fixer',
                         'exclude': r'^docs/assets/fonts/OFL\.txt$',
                     },
+                    # Unanchored, so it matches only under `search`. Were the
+                    # check to anchor at position 0 the way `match` does, this
+                    # live exclusion would be reported as stale.
+                    {'id': 'check-yaml', 'exclude': r'fonts/OFL\.txt$'},
                     {'id': 'ruff', 'exclude': NULL_EXCLUDE},
                 ]
             }
@@ -149,3 +155,41 @@ def test_stale_exclude_is_reported():
     # A config-level exclusion is checked too, and goes stale the same way.
     config['exclude'] = r'^docs/assets/'
     assert ('<config>', r'^docs/assets/') in _stale_excludes(config, files)
+
+
+def test_tracked_files_stands_down_instead_of_raising(monkeypatch):
+    """`_tracked_files` answers None wherever git cannot supply a file list.
+
+    The check has to stand down when the tree cannot be enumerated, so both
+    routes to that state return None and the caller skips rather than
+    reporting every exclusion as stale. A path that is not valid UTF-8
+    survives the round trip as surrogates, so an undecodable name in the tree
+    leaves the rest of the check working instead of raising mid-call.
+    """
+    monkeypatch.setattr(shutil, 'which', lambda name: None)
+    assert _tracked_files() is None
+
+    monkeypatch.setattr(shutil, 'which', lambda name: '/usr/bin/git')
+
+    def _fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, 'git')
+
+    monkeypatch.setattr(subprocess, 'run', _fail)
+    assert _tracked_files() is None
+
+    undecodable = b'docs/f\xffle.txt'.decode('utf-8', 'surrogateescape')
+    seen = {}
+
+    def _listing(*args, **kwargs):
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(args, 0, f'README.md\0{undecodable}\0', '')
+
+    monkeypatch.setattr(subprocess, 'run', _listing)
+    assert _tracked_files() == ['README.md', undecodable]
+    # Decoding is pinned rather than taken from the locale. Left to the
+    # locale, a C-locale runner raises on the first non-ASCII path and the
+    # exception escapes the clause above, which only covers process failures.
+    assert (seen.get('encoding'), seen.get('errors')) == ('utf-8', 'surrogateescape')
+    # The trailing NUL must not become an empty path, which would match any
+    # unanchored exclusion and hide a stale one.
+    assert '' not in _tracked_files()


### PR DESCRIPTION
## Description

pre-commit treats an `exclude` regex that matches nothing as a no-op rather than an error, so an exclusion silently stops applying the moment the file it names is moved or renamed. The vendored SIL Open Font License is excluded from `trailing-whitespace` and `end-of-file-fixer` on exactly that basis. A further docs-asset reshuffle would quietly hand it back to those hooks, and `Code style` would then go red for what looks like an unrelated regression, with nothing pointing at the path change that caused it.

This adds a test that reads `.pre-commit-config.yaml`, enumerates the tracked files with `git ls-files`, and fails when any exclusion, config-level or per-hook, no longer matches one of them. The failure names the hook and the regex. A second test feeds the checker a config whose exclusion points at a moved font directory and asserts that only the dead one is reported, so the guard cannot pass on a broken config. A third covers the routes by which the check stands down, so it fails rather than skipping quietly if the tree cannot be enumerated.

The check is one-sided by design. It works from the full tracked-file set rather than the narrower set a hook actually inspects, so it never fires merely because a hook would have filtered a match out by type, and it does not catch an exclusion that is dead only within one hook's own file selection. `pyyaml` joins the `develop` extra because the test parses the config directly.

pre-commit's built-in `check-useless-excludes` meta hook covers a stricter version of the same property, but not this failure: `Code style` runs pre-commit as `--files $ALL_CHANGED_FILES`, so the meta hook only fires on commits that touch `.pre-commit-config.yaml`, and the case being guarded is a commit that moves the fonts and leaves the config alone. The test suite runs on every pull request regardless of which files changed.

## Validation of changes

Renaming `docs/stylesheets/fonts/OFL.txt` in a working tree makes the new test fail, naming both hooks and the dead regex; restoring the name makes it pass. That is the actual break being guarded, not a mocked stand-in.

`pytest -m "(unit or smoke) and not skip"` gives 351 passed. `bash tools/validate_test_structure.sh`, `python tools/check_test_quality.py --check`, `ruff check`, `ruff format --check`, and `pre-commit run --all-files` are all clean. Tested on macOS 15 with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/CALLIOPE/Community/CONTRIBUTING.html)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
